### PR TITLE
[F2F-457] ACM certificate for hosted zone

### DIFF
--- a/infra-l2-dns-acm-certificate/template.yaml
+++ b/infra-l2-dns-acm-certificate/template.yaml
@@ -27,11 +27,6 @@ Parameters:
       - integration
       - production
 
-# SSM /dev/Platform/Route53/PrimaryZoneID Z01708682B7XWP3ZCU52R
-# PublicHostedZoneId
-
-
-
 Resources:
   ExternalCertificate:
     Type: AWS::CertificateManager::Certificate

--- a/infra-l2-dns-acm-certificate/template.yaml
+++ b/infra-l2-dns-acm-certificate/template.yaml
@@ -1,0 +1,98 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Creates the necessary components to deploy a TLS certificate for the domain used in F2F CRI.
+
+Mappings:
+  PlatformConfiguration:
+    dev:
+      DNSSUFFIX: review-o.dev.account.gov.uk
+    build:
+      DNSSUFFIX: review-o.build.account.gov.uk
+    staging:
+      DNSSUFFIX: review-o.staging.account.gov.uk
+    integration:
+      DNSSUFFIX: review-o.integration.account.gov.uk
+    production:
+      DNSSUFFIX: review-o.account.gov.uk
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+
+# SSM /dev/Platform/Route53/PrimaryZoneID Z01708682B7XWP3ZCU52R
+# PublicHostedZoneId
+
+
+
+Resources:
+  ExternalCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub
+      - "${DNSSUFFIX}"
+      - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+
+      SubjectAlternativeNames:
+      - !Sub
+        - "api.${DNSSUFFIX}"
+        - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+      - !Sub
+        - "www.${DNSSUFFIX}"
+        - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+      - !Sub
+        - "app.${DNSSUFFIX}"
+        - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+      - !Sub
+        - "*.${DNSSUFFIX}"
+        - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+
+      DomainValidationOptions:
+        - DomainName: !Sub
+          - "${DNSSUFFIX}"
+          - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+          HostedZoneId: !ImportValue PublicHostedZoneId
+        - DomainName: !Sub
+          - "api.${DNSSUFFIX}"
+          - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+          HostedZoneId: !ImportValue PublicHostedZoneId
+        - DomainName: !Sub
+          - "www.${DNSSUFFIX}"
+          - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+          HostedZoneId: !ImportValue PublicHostedZoneId
+        - DomainName: !Sub
+          - "app.${DNSSUFFIX}"
+          - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+          HostedZoneId: !ImportValue PublicHostedZoneId
+      ValidationMethod: DNS
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - "${DNSSUFFIX}"
+            - DNSSUFFIX: !FindInMap [ PlatformConfiguration, !Ref Environment, DNSSUFFIX ]
+        - Key: Product
+          Value: "GOV.UK Sign In"
+        - Key: System
+          Value: "F2F CRI"
+        - Key: Environment
+          Value: !Sub "${Environment}"
+
+  CertificateARNSSM:
+    Type: AWS::SSM::Parameter
+    Properties:    
+      Description: The Certificate ARN
+      Name: !Sub "/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN"
+      Type: String
+      Value: !Ref ExternalCertificate
+      Tags:
+        Name: !Sub "/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN"
+        Product: "GOV.UK Sign In"
+        System: "F2F CRI"
+        Environment: !Sub "${Environment}"


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a TLS certificate generated by ACM for the hosted zone deployed in to the account

### Why did it change

AWS resources wishing to use this custom domain need access to the certificate in TLS

### Issue tracking

- [F2F-457](https://govukverify.atlassian.net/browse/F2F-457)

## Checklists

### Environment variables or secrets

Create a new SSM parameter `/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN` containing the ARN for the certificate

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-457]: https://govukverify.atlassian.net/browse/F2F-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ