### PR TITLE
[F2F-347] Add Yoti integration to outbound proxy

### DIFF
--- a/infra-l2-outbound-proxy/template.yaml
+++ b/infra-l2-outbound-proxy/template.yaml
@@ -16,18 +16,23 @@ Mappings:
   EnvironmentVariables:
     dev:
       POSTOFFICEURL: "https://locations.pol-platform.co.uk"
+      YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.dev.account.gov.uk"
     build:
       POSTOFFICEURL: "https://locations.pol-platform.co.uk"
+      YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.build.account.gov.uk"
     staging:
       POSTOFFICEURL: "https://locations.pol-platform.co.uk"
+      YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.staging.account.gov.uk"
     integration:
       POSTOFFICEURL: "https://locations.pol-platform.co.uk"
+      YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.integration.account.gov.uk"
     production:
       POSTOFFICEURL: "https://locations.pol-platform.co.uk"
+      YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.account.gov.uk"
 
 Parameters:
@@ -74,6 +79,29 @@ Resources:
         - /
         - - integrations
           - !Ref PostOfficeProxyApiGatewayIntegration
+
+  YotiProxyApiGatewayIntegration:
+    Type: 'AWS::ApiGatewayV2::Integration'
+    Properties:
+      ApiId: !Ref OutboundProxyApiGatewayAPI
+      Description: HTTP proxy integration with Yoti endpoints
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      IntegrationUri: !Sub
+        - "${URL}/{proxy}"
+        - URL:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, YOTIURL ]
+      PayloadFormatVersion: '1.0'
+
+  YotiProxyApiGatewayRoute:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref OutboundProxyApiGatewayAPI
+      RouteKey: 'ANY /yoti/{proxy+}'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref YotiProxyApiGatewayIntegration
 
   OutboundProxyApiGatewayStageDefault:
     Type: 'AWS::ApiGatewayV2::Stage'


### PR DESCRIPTION
## Proposed changes

### What changed

Add the `/yoti` and Yoti proxy integration to the outbound proxy APIGW

### Why did it change

Integrate the Yoti service following the same pattern as with PO

### Issue tracking

- [F2F-347](https://govukverify.atlassian.net/browse/F2F-347)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-347]: https://govukverify.atlassian.net/browse/F2F-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ