### PR TITLE
[F2F-471] Add custom domain definition and mapping for BE APIGW

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -669,3 +669,11 @@ Outputs:
     Value: !Sub "${F2FRestApi}"
     Export:
       Name: !Sub ${AWS::StackName}-F2FApiGatewayId
+  F2FBackendURL:
+    Description: "F2F Backend URL"
+    Value: !Sub
+      - "https://api-${AWS::StackName}.${DNSSUFFIX}/"
+      - DNSSUFFIX:
+          !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+    Export:
+      Name: !Sub ${AWS::StackName}-F2FBackendURL

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -304,8 +304,8 @@ Resources:
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
       AliasTarget:
-        DNSName: "F2FApiCustomDomainName"
-        HostedZoneId: "F2FApiCustomDomainName"
+        DNSName: !GetAtt F2FApiCustomDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt F2FApiCustomDomainName.RegionalHostedZoneId
 
   ### End of API Gateway Custom Domain definition
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,18 +59,23 @@ Mappings:
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       ISSUER: 'https://review-o.dev.account.gov.uk'
+      DNSSUFFIX: review-o.dev.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
     build:
       ISSUER: 'https://review-o.build.account.gov.uk'
+      DNSSUFFIX: review-o.build.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
     staging:
       ISSUER: 'https://review-o.staging.account.gov.uk'
+      DNSSUFFIX: review-o.staging.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
     integration:
       ISSUER: 'https://review-o.integration.account.gov.uk'
+      DNSSUFFIX: review-o.integration.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
     production:
       ISSUER: 'https://review-o.account.gov.uk'
+      DNSSUFFIX: review-o.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
   TxMAAccounts:
     # EVENTS is used to egress to TxMA.
@@ -262,6 +267,47 @@ Resources:
           Value: APIGatewayAccessLogGroup
 
   ### End of API Gateway definition.
+
+  ### API Gateway Custom Domain definition
+
+  F2FApiCustomDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      DomainName: !Sub
+        - "api-${AWS::StackName}.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      RegionalCertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
+      SecurityPolicy: TLS_1_2
+
+  F2FApiBasePath:
+    Type: AWS::ApiGateway::BasePathMapping
+    DependsOn: "F2FApiCustomDomainName"
+    Properties:
+      DomainName: !Sub
+        - "api-${AWS::StackName}.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      RestApiId: !Ref F2FRestApi
+      Stage: !Sub "${F2FRestApi.Stage}"
+
+  F2FApiCertificateRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Sub
+        - "api-${AWS::StackName}.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      Type: A
+      HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
+      AliasTarget:
+        DNSName: "F2FApiCustomDomainName"
+        HostedZoneId: "F2FApiCustomDomainName"
+
+  ### End of API Gateway Custom Domain definition
 
   ### Function Definition
   ## AccessToken

--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,9 @@ From `src` folder run `sam build`
 
 ## How to run tests
 
-To run all tests, run `npm test:unit`. This will compile and run all tests in the `/tests` directory.
+To run all unit tests, run `npm run test:unit`. This will compile and run all the unit tests in the `/tests` directory.
+
+To run the infra tests, run `npm run test:infra`.
 
 ### How to perform lint checks an individual test file
 

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -110,13 +110,42 @@ describe("Infra", () => {
 		});
 	});
 
-	it("should define a DNS record for the custom domain", () => {
+	it("should define a DNS record for each custom domain", () => {
 		const customDomainNames = template.findResources("AWS::ApiGateway::DomainName");
 		const customDomainNameList = Object.keys(customDomainNames);
 		customDomainNameList.forEach((customDomainName) => {
 			template.hasResourceProperties("AWS::Route53::RecordSet", {
 				Name: customDomainNames[customDomainName].Properties.DomainName
 			});
+		});
+	});
+
+	it("should define an output with the API Gateway ID", () => {
+		template.hasOutput("F2FApiGatewayId", {
+			Value: {
+				"Fn::Sub": "${F2FRestApi}",
+			},
+		});
+	});
+
+	it("should define an output with the F2F Backend URL using the custom domain name", () => {
+		template.hasOutput("F2FBackendURL", {
+			Value: {
+				"Fn::Sub": [
+					"https://api-${AWS::StackName}.${DNSSUFFIX}/",
+					{
+						DNSSUFFIX: {
+							"Fn::FindInMap": [
+								"EnvironmentVariables",
+								{
+									Ref: "Environment",
+								},
+								"DNSSUFFIX"
+							],
+						},
+					},
+				],
+			},
 		});
 	});
 

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -88,6 +88,38 @@ describe("Infra", () => {
 		});
 	});
 
+	it("Each regional API Gateway should have at least one custom domain base path mapping name defined", () => {
+		const gateways = template.findResources("AWS::Serverless::Api");
+		const gatewayList = Object.keys(gateways);
+		gatewayList.forEach((gateway) => {
+			template.hasResourceProperties("AWS::ApiGateway::BasePathMapping", {
+				RestApiId: {
+					Ref: gateway,
+				}
+			});
+		});
+	});
+
+	it("Each custom domain referenced in a BasePathMapping should be defined", () => {
+		const basePathMappings = template.findResources("AWS::ApiGateway::BasePathMapping");
+		const basePathMappingList = Object.keys(basePathMappings);
+		basePathMappingList.forEach((basePathMapping) => {
+			template.hasResourceProperties("AWS::ApiGateway::DomainName", {
+				DomainName: basePathMappings[basePathMapping].Properties.DomainName
+			});
+		});
+	});
+
+	it("should define a DNS record for the custom domain", () => {
+		const customDomainNames = template.findResources("AWS::ApiGateway::DomainName");
+		const customDomainNameList = Object.keys(customDomainNames);
+		customDomainNameList.forEach((customDomainName) => {
+			template.hasResourceProperties("AWS::Route53::RecordSet", {
+				Name: customDomainNames[customDomainName].Properties.DomainName
+			});
+		});
+	});
+
 	describe("Log group retention", () => {
 		it.each`
     environment      | retention


### PR DESCRIPTION
## Proposed changes

### What changed

Adds custom domain DNS record, APIGW custom domain definition and base path mapping for the backend API Gateway, and associated infra tests

### Why did it change

Custom domains need to be defined alongside the APIGW resource definition in the same template, so they are created and destroyed together

### Issue tracking

- [F2F-471](https://govukverify.atlassian.net/browse/F2F-471)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-471]: https://govukverify.atlassian.net/browse/F2F-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ