### PR TITLE
F2F-501: Adding IPV Stub subdomain and api mapping

### DIFF
--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -298,10 +298,13 @@ Resources:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
-          REDIRECT_URI: !Sub
+          REDIRECT_URI: !If
+          - CreateDevResources
+          - !Sub
             - "https://${AWS::StackName}-${IPVSTUBURL}/redirect"
             - IPVSTUBURL:
                 !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
+          - !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
           JWKS_URI: !FindInMap [Configuration, !Ref Environment, JWKSURI]
           OAUTH_FRONT_BASE_URI: !Sub  "https://review-o.${Environment}.account.gov.uk"
       Policies:
@@ -503,10 +506,14 @@ Resources:
   IPVStubExternalApiCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
-      DomainName: !Sub
-        - "${AWS::StackName}-${IPVSTUBURL}"
-        - IPVSTUBURL:
-            !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
+      DomainName: !If
+        - CreateDevResources
+        - !Sub
+          - "${AWS::StackName}-${IPVSTUBURL}"
+          - IPVSTUBURL:
+              !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
+        - !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
+
       DomainNameConfigurations:
         - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
           EndpointType: REGIONAL

--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -296,9 +296,9 @@ Resources:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
-          REDIRECT_URI: !Sub "https://ipvstub.review-c.${Environment}.account.gov.uk/redirect"
+          REDIRECT_URI: !Sub "https://ipvstub.review-o.${Environment}.account.gov.uk/redirect"
           JWKS_URI: !FindInMap [Configuration, !Ref Environment, JWKSURI]
-          OAUTH_FRONT_BASE_URI: !Sub  "https://review-c.${Environment}.account.gov.uk"
+          OAUTH_FRONT_BASE_URI: !Sub  "https://review-o.${Environment}.account.gov.uk"
       Policies:
         - Statement:
             - Sid: KMSSignPolicy
@@ -495,14 +495,50 @@ Resources:
       Tags:
         APP: !Sub f2f-${AWS::StackName}
 
+  IPVStubExternalApiCustomDomain:
+    Type: AWS::ApiGatewayV2::DomainName
+    Properties:
+      DomainName: !Sub "ipvstub.review-o.${Environment}.account.gov.uk"
+      DomainNameConfigurations:
+        - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+
+  IPVStubExternalApiRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Ref IPVStubExternalApiCustomDomain
+      Type: A
+      HostedZoneId: !ImportValue PublicHostedZoneId
+      AliasTarget:
+        DNSName: !GetAtt IPVStubExternalApiCustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt IPVStubExternalApiCustomDomain.RegionalHostedZoneId
+        EvaluateTargetHealth: false
+
+  IPVStubExternalApiMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Properties:
+      DomainName: !Ref IPVStubExternalApiCustomDomain
+      ApiId: !Ref IPVStubApiGw
+      Stage: !Ref Environment
+    DependsOn:
+      - IPVStubApiGwDeployment
+
 Outputs:
   IPVStubExecuteUrl:
     Description: "API Gateway endpoint URL for the environment stage"
     Value: !Sub "https://${IPVStubApiGw}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
-    Export:
-      Name: !Sub "${AWS::StackName}-IPVStubExecuteUrl"
-  IPVStubApiGw:
+
+  IPVStubApiGwId:
     Description: "The ID of the API Gateway"
-    Value: !Ref IPVStubApiGw
     Export:
-      Name: "f2f-cri-IPVStubApiGw"
+      Name: !Sub "${AWS::StackName}-IPVStubApiGwId"
+    Value: !Ref IPVStubApiGw
+
+  IPVStubPrettyApiUrl:
+    Description: Pretty URL for IPV Stub
+    Export:
+      Name: !Sub "${AWS::StackName}-IPvStubApiGatewayPrettyUrl"
+    Value: !Sub
+      - "https://${URL}/"
+      - URL: !Ref IPVStubExternalApiCustomDomain

--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -535,6 +535,8 @@ Resources:
 Outputs:
   IPVStubExecuteUrl:
     Description: "API Gateway endpoint URL for the environment stage"
+    Export:
+      Name: !Sub "${AWS::StackName}-IPVStubExecuteUrl"
     Value: !Sub "https://${IPVStubApiGw}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
 
   IPVStubApiGwId:

--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -43,15 +43,17 @@ Mappings:
     dev:
       IPVStubID: "5C584572"
       JWKSURI: "https://api-f2f-cri-api.review-o.dev.account.gov.uk"
+      IPVSTUBURL: "ipvstub.review-o.dev.account.gov.uk"
     build:
       IPVStubID: "BD7B2A5D"
       JWKSURI: "https://api.review-o.build.account.gov.uk"
+      IPVSTUBURL: "ipvstub.review-o.build.account.gov.uk"
     staging:
       IPVStubID: "9CDA6F61"
     integration:
       IPVStubID: "AE140E43"
-    production:
-      IPVStubID: "C910A762"
+#    production:
+#      IPVStubID: "C910A762"
 
 Conditions:
   CreateDevResources: !Equals
@@ -296,7 +298,10 @@ Resources:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
-          REDIRECT_URI: !Sub "https://ipvstub.review-o.${Environment}.account.gov.uk/redirect"
+          REDIRECT_URI: !Sub
+            - "https://${AWS::StackName}-${IPVSTUBURL}/redirect"
+            - IPVSTUBURL:
+                !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
           JWKS_URI: !FindInMap [Configuration, !Ref Environment, JWKSURI]
           OAUTH_FRONT_BASE_URI: !Sub  "https://review-o.${Environment}.account.gov.uk"
       Policies:
@@ -498,7 +503,10 @@ Resources:
   IPVStubExternalApiCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
-      DomainName: !Sub "ipvstub.review-o.${Environment}.account.gov.uk"
+      DomainName: !Sub
+        - "${AWS::StackName}-${IPVSTUBURL}"
+        - IPVSTUBURL:
+            !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
       DomainNameConfigurations:
         - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
           EndpointType: REGIONAL


### PR DESCRIPTION
## Proposed changes

### What changed

Adding IPV Stub subdomain and api mapping 

### Why did it change

To enable other components like F2F /session to call its well-known endpoint to fetch the public key

### Issue tracking
- [F2F-501](https://govukverify.atlassian.net/browse/F2F-501)

## Checklists

### Testing
<img width="1184" alt="Screenshot 2023-04-11 at 12 01 51" src="https://user-images.githubusercontent.com/26764987/231141321-efa9e2e0-cfa3-4691-8809-ff0152560dca.png">

<img width="1316" alt="Screenshot 2023-04-11 at 12 02 06" src="https://user-images.githubusercontent.com/26764987/231141346-67849208-d839-4be9-9c3c-cb36c829f1e6.png">


[F2F-501]: https://govukverify.atlassian.net/browse/F2F-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ