### PR TITLE
F2F | Platform | Infrastructure work for Yoti Callback Handler

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -20,6 +20,93 @@ tags:
 
 paths:
 
+  /callback:
+    post:
+      operationId: postCallback
+      summary: callback endpoint for asynchronous notifications from Yoti
+      description: >-
+        Endpoint is registered as the notifications callback with Yoti in the
+        call to `POST /session`
+      tags:
+        - Callback
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CallbackRequest'
+      responses:
+        '202':
+          description: Accepted
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            Strict-Transport-Security:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+            X-Frame-Options:
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            Strict-Transport-Security:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+            X-Frame-Options:
+              schema:
+                type: string
+        '500':
+          description: Internal Server Error
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            Strict-Transport-Security:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+            X-Frame-Options:
+              schema:
+                type: string
+      x-amazon-apigateway-request-validator: both
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        credentials:
+          Fn::GetAtt: [ "YotiCallbackQueueRole", "Arn" ]
+        uri: 
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:sqs:path/${AWS::AccountId}/${YotiCallbackQueue.QueueName}"
+        passthroughBehavior: "never"
+        requestParameters:
+          integration.request.header.Content-Type: "'application/x-www-form-urlencoded'"
+        requestTemplates:
+          application/json: "Action=SendMessage&MessageBody=$input.body"
+        responses:
+          default:
+            statusCode: "202"
+        type: "aws"
+
   /token:
     post:
       operationId: postToken
@@ -493,6 +580,36 @@ paths:
 
 components:
   schemas:
+    CallbackRequest:
+      description: "payload received from Yoti for a notification callback"
+      required:
+        - session_id
+        - topic
+      additionalProperties: true
+      properties:
+        session_id:
+          type: string
+          format: uuid
+          description: "session_id as returned in original call to `POST /session`"
+          example: "11111111-1111-1111-1111-111111111111"
+        topic:
+          type: string
+          enum:
+            - "resource_update"
+            - "task_completion"
+            - "check_completion"
+            - "session_completion"
+          description: indicates notification message type
+          example: "session_completion"
+        task_id:
+          type: string
+          description: "Optional and present only when `topic` is `task_completion`"
+        resource_id:
+          type: string
+          description: "Optional and present only when `topic` is `resource_update`"
+        check_id:
+          type: string
+          description: "Optional and present only when `topic` is `check_completion`"
     AuthorizationResponse:
       required:
         - "redirect_uri"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -952,6 +952,87 @@ Resources:
       FunctionName: !Ref GovNotifyFunction
       Principal: apigateway.amazonaws.com
 
+  YotiCallbackQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      MessageRetentionPeriod: !FindInMap [EnvironmentVariables, !Ref Environment, MESSAGERETENTIONPERIODDAYS]
+      VisibilityTimeout: 60
+      KmsMasterKeyId: !Ref YotiCallbackKeyAlias
+      RedrivePolicy:
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - "YotiCallbackQueueDeadLetterQueue"
+            - "Arn"
+        maxReceiveCount: 5
+
+  YotiCallbackQueueDeadLetterQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      MessageRetentionPeriod: 259200 # three days
+      KmsMasterKeyId: !Sub YotiCallbackEncryptionKey
+
+  YotiCallbackQueueRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: YotiCallbackQueuePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "sqs:SendMessage"
+                Resource: !GetAtt YotiCallbackQueue.Arn
+              - Effect: Allow
+                Action:
+                  - "kms:Encrypt"
+                  - "kms:Decrypt"
+                  - "kms:GenerateDataKey"
+                Resource: !GetAtt YotiCallbackEncryptionKey.Arn
+
+  YotiCallbackEncryptionKey:
+    Type: AWS::KMS::Key
+    # KMS Key manually rotated.
+    # checkov:skip=CKV_AWS_7: KMS Key manually rotated.
+    Properties:
+      Description: A KMS Key for encrypting the SQS Queue for YotiCallback
+      Enabled: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource:
+              - "*"
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT
+      MultiRegion: false
+      PendingWindowInDays: 7
+      Tags:
+        - Key: KeyType
+          Value: Encryption Key
+        - Key: Environment
+          Value: !Sub ${Environment}
+
+  YotiCallbackKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !If
+        - CreateDevResources
+        - !Sub "alias/YotiCallbackEncryptionKey-${AWS::StackName}"
+        - alias/YotiCallbackEncryptionKey
+      TargetKeyId: !Ref YotiCallbackEncryptionKey
+
   #Gov Notify SQS Queue
   GovNotifySQSQueue:
     Type: "AWS::SQS::Queue"


### PR DESCRIPTION
### What changed

Creates a new /callback endpoint within the F2F CRI apigw
POST calls to this ensdpoint funnel the payload body directly to a new SQS, YotiCallbackQueue which has a DLQ attached and is ecrypted using the YotiCallbackEncryptionKey

**POST to endpoint via Postman**
<img width="1357" alt="image" src="https://user-images.githubusercontent.com/13416125/232460610-efac8cae-d447-4662-b3bb-a2be565c149d.png">

**Message in SQS Queue**
<img width="876" alt="image" src="https://user-images.githubusercontent.com/13416125/232460722-d1524e0e-fff9-4edd-9963-d70997449206.png">
