### PR TITLE
F2F-100: Sonar scan to F2F repos

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,4 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.tests=src/
 sonar.test.inclusions=**/*.test.js
 # Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Fix to enable coverage on the sonar scan

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Enable the SonarEncoding to UTF-8 as the coverage was showing 0.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-XXX](https://govukverify.atlassian.net/browse/F2F-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks