### PR TITLE
Adding permissions boundary for YotiQueueRole

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -535,7 +535,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
    # Condition: IsProdLikeEnvironment
     Properties:
-      DestinationArn: 
+      DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref TokenFunctionLogGroup
@@ -617,7 +617,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     # Condition: IsProdLikeEnvironment
     Properties:
-      DestinationArn: 
+      DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref AuthorizationFunctionLogGroup
@@ -724,7 +724,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     # Condition: IsProdLikeEnvironment
     Properties:
-      DestinationArn: 
+      DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref DocumentSelectionLogGroup
@@ -1308,6 +1308,10 @@ Resources:
                   - "kms:Decrypt"
                   - "kms:GenerateDataKey"
                 Resource: !GetAtt YotiCallbackEncryptionKey.Arn
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 
   YotiCallbackEncryptionKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
## Proposed changes

### What changed

Add PermissionsBoundary to `YotiCallbackQueueRole` as its required by pipelines on higher environments in order to create a new role   

### Tested by deploying onto F2F Dev environment
