### PR TITLE
[F2F-502] Convert Yoti Response into VC Format

### DIFF
--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,10 +2,10 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "backend-viveak"
-s3_prefix = "backend-viveak"
+stack_name = "backend-main"
+s3_prefix = "backend-main"
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" L2DynamoStackName=\"infra-l2-dynamo-viveak\" L2KMSStackName=\"infra-l2-kms-viveak\""
+parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" L2DynamoStackName=\"f2f-cri-ddb\" L2KMSStackName=\"f2f-cri-kms\""
 image_repositories = []

--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,10 +2,10 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "backend-main"
-s3_prefix = "backend-main"
+stack_name = "backend-viveak"
+s3_prefix = "backend-viveak"
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" L2DynamoStackName=\"f2f-cri-ddb\" L2KMSStackName=\"f2f-cri-kms\""
+parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" L2DynamoStackName=\"infra-l2-dynamo-viveak\" L2KMSStackName=\"infra-l2-kms-viveak\""
 image_repositories = []

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -715,7 +715,6 @@ Resources:
             Method: post
             RestApiId: !Ref F2FRestApi
     Metadata:
-      # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
         Minify: true
@@ -723,7 +722,6 @@ Resources:
         Sourcemap: false # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints:
           - DocumentSelectionHandler.ts
-
 
   DocumentSelectionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -73,7 +73,6 @@ Mappings:
     dev:
       YOTIBASEURL: "https://f2f-yoti-stub-yotistub.review-o.dev.account.gov.uk"
       YOTISDK: "MockSDK"
-      YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.dev.account.gov.uk'
       DNSSUFFIX: review-o.dev.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
@@ -86,7 +85,6 @@ Mappings:
     build:
       YOTIBASEURL: "https://proxy.review-o.build.account.gov.uk/yoti"
       YOTISDK: "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
-      YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.build.account.gov.uk'
       DNSSUFFIX: review-o.build.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
@@ -99,7 +97,6 @@ Mappings:
     staging:
       YOTIBASEURL: "https://proxy.review-o.staging.account.gov.uk/yoti"
       YOTISDK: "596d953d-2451-46c8-8553-ebb0d1a75698"
-      YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.staging.account.gov.uk'
       DNSSUFFIX: review-o.staging.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
@@ -112,7 +109,6 @@ Mappings:
     integration:
       YOTIBASEURL: "https://proxy.review-o.integration.account.gov.uk/yoti"
       YOTISDK: "cb78093e-0686-4f86-8e7c-ded6117502e8"
-      YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.integration.account.gov.uk'
       DNSSUFFIX: review-o.integration.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
@@ -125,7 +121,6 @@ Mappings:
     production:
       YOTIBASEURL: "https://proxy.review-o.account.gov.uk/yoti"
       YOTISDK: "81402882-b37c-4348-b336-437cdbb232bb"
-      YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.account.gov.uk'
       DNSSUFFIX: review-o.account.gov.uk
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
@@ -652,14 +647,22 @@ Resources:
           POWERTOOLS_SERVICE_NAME: DocumentSelectionHandler
           ISSUER: !FindInMap [EnvironmentVariables, !Ref Environment, ISSUER]
           PERSON_IDENTITY_TABLE_NAME:
-            Fn::ImportValue:
-              !Sub "${L2DynamoStackName}-person-identity-table-name"
-          YOTICALLBACKURL: !FindInMap [EnvironmentVariables, !Ref Environment, YOTICALLBACKURL]
+            Fn::ImportValue: !Sub "${L2DynamoStackName}-person-identity-table-name"
+          YOTICALLBACKURL: !If
+            - CreateDevResources
+            - !Sub
+              - "https://api-${AWS::StackName}.${DNSSUFFIX}/callback"
+              - DNSSUFFIX:
+                  !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
+            - !Sub
+              - "https://api.${DNSSUFFIX}/callback"
+              - DNSSUFFIX:
+                  !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
           GOV_NOTIFY_QUEUE_URL: !Ref GovNotifySQSQueue
           TXMA_QUEUE_URL: !Ref TxMASQSQueue
           YOTI_KEY_SSM_PATH: !Sub "/${Environment}/YOTI/PRIVATEKEY"
-          YOTIBASEURL: !FindInMap [ EnvironmentVariables, !Ref Environment, YOTIBASEURL ]
-          YOTISDK: !FindInMap [ EnvironmentVariables, !Ref Environment, YOTISDK ]
+          YOTIBASEURL: !FindInMap [EnvironmentVariables, !Ref Environment, YOTIBASEURL]
+          YOTISDK: !FindInMap [EnvironmentVariables, !Ref Environment, YOTISDK]
           CLIENT_SESSION_TOKEN_TTL_SECS: !FindInMap [EnvironmentVariables, !Ref Environment, CLIENTSESSIONTOKENTTL]
           RESOURCES_TTL_SECS: !FindInMap [EnvironmentVariables, !Ref Environment, RESOURCESTTL]
       Policies:
@@ -668,47 +671,42 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${Environment}/YOTI/PRIVATEKEY"
         - DynamoDBReadPolicy:
-            TableName:
-              Fn::ImportValue:
-                !Sub "${L2DynamoStackName}-person-identity-table-name"
+            TableName: !ImportValue
+              Fn::Sub: "${L2DynamoStackName}-person-identity-table-name"
         - DynamoDBReadPolicy:
-            TableName:
-              Fn::ImportValue:
-                !Sub "${L2DynamoStackName}-session-table-name"
+            TableName: !ImportValue
+              Fn::Sub: "${L2DynamoStackName}-session-table-name"
         - DynamoDBWritePolicy:
-            TableName:
-              Fn::ImportValue:
-                !Sub "${L2DynamoStackName}-session-table-name"
+            TableName: !ImportValue
+              Fn::Sub: "${L2DynamoStackName}-session-table-name"
         - KMSDecryptPolicy:
-            KeyId:
-              Fn::ImportValue:
-                !Sub "${L2DynamoStackName}-person-identity-table-key-id"
+            KeyId: !ImportValue
+              Fn::Sub: "${L2DynamoStackName}-person-identity-table-key-id"
         - KMSDecryptPolicy:
-            KeyId:
-              Fn::ImportValue:
-                !Sub "${L2DynamoStackName}-session-table-key-id"
+            KeyId: !ImportValue
+              Fn::Sub: "${L2DynamoStackName}-session-table-key-id"
         - Statement:
             - Effect: Allow
               Action:
                 - "sqs:SendMessage"
-              Resource: !GetAtt TxMASQSQueue.Arn
+              Resource: !GetAtt [TxMASQSQueue, Arn]
             - Effect: Allow
               Action:
                 - "kms:Encrypt"
                 - "kms:Decrypt"
                 - "kms:GenerateDataKey"
-              Resource: !GetAtt TxMAKMSEncryptionKey.Arn
+              Resource: !GetAtt [TxMAKMSEncryptionKey, Arn]
         - Statement:
             - Effect: Allow
               Action:
                 - "sqs:SendMessage"
-              Resource: !GetAtt GovNotifySQSQueue.Arn
+              Resource: !GetAtt [GovNotifySQSQueue, Arn]
             - Effect: Allow
               Action:
                 - "kms:Encrypt"
                 - "kms:Decrypt"
                 - "kms:GenerateDataKey"
-              Resource: !GetAtt GovNotifyEncryptionKey.Arn
+              Resource: !GetAtt [GovNotifyEncryptionKey, Arn]
       Events:
         documentSelection:
           Type: Api
@@ -716,7 +714,8 @@ Resources:
             Path: /documentSelection
             Method: post
             RestApiId: !Ref F2FRestApi
-    Metadata: # Manage esbuild properties
+    Metadata:
+      # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
         Minify: true
@@ -724,6 +723,7 @@ Resources:
         Sourcemap: false # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints:
           - DocumentSelectionHandler.ts
+
 
   DocumentSelectionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -99,6 +99,7 @@ Resources:
               - "state"
               - "clientId"
               - "clientSessionId"
+              - "authSessionState"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiryDate

--- a/src/YotiCallbackHandler.ts
+++ b/src/YotiCallbackHandler.ts
@@ -53,10 +53,8 @@ class YotiCallbackHandler implements LambdaInterface {
 				if (body.topic === "session_completion") {
 					await YotiCallbackProcessor.getInstance(logger, metrics, YOTI_PRIVATE_KEY).processRequest(body);
 				} else {
-					{
-						logger.warn("Unexpected topic received in request");
-						return new Response(HttpCodesEnum.BAD_REQUEST, "Unexpected topic received in request");
-					}
+					logger.warn("Unexpected topic received in request");
+					return new Response(HttpCodesEnum.BAD_REQUEST, "Unexpected topic received in request");
 				}
 				
 

--- a/src/YotiCallbackHandler.ts
+++ b/src/YotiCallbackHandler.ts
@@ -50,7 +50,15 @@ class YotiCallbackHandler implements LambdaInterface {
 					}
 				}
 				
-				await YotiCallbackProcessor.getInstance(logger, metrics, YOTI_PRIVATE_KEY).processRequest(body);
+				if (body.topic === "session_completion") {
+					await YotiCallbackProcessor.getInstance(logger, metrics, YOTI_PRIVATE_KEY).processRequest(body);
+				} else {
+					{
+						logger.warn("Unexpected topic received in request");
+						return new Response(HttpCodesEnum.BAD_REQUEST, "Unexpected topic received in request");
+					}
+				}
+				
 
 				logger.debug("Finished processing record from SQS");
 				return new Response(HttpCodesEnum.OK, {

--- a/src/models/YotiPayloads.ts
+++ b/src/models/YotiPayloads.ts
@@ -246,3 +246,30 @@ export interface YotiCompletedSession {
 	}>;
 	user_tracking_id: string;
 }
+
+export interface YotiCheckRecommendation {
+	value: string;
+	reason?: string;
+}
+
+export interface YotiDocumentFields {
+	given_names: string;
+	family_name: string;
+	date_of_birth: string; 
+	structured_postal_address?: YotiDocumentFieldsAddressInfo; 
+	document_number?: string;
+	expiration_date?: string;
+	issuing_country?: string;
+	date_of_issue?: string;
+	issuing_authority?: string;
+	formatted_address?: string;
+	place_of_issue?: string;
+}
+
+export interface YotiDocumentFieldsAddressInfo {
+	address_line1: string;
+	building_number: string;
+	town_city: string;
+	postal_code: string; 
+	country: string; 
+}

--- a/src/package.json
+++ b/src/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.21"
   },
   "scripts": {
-    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit/services/YotiCallbackProcessor.test.ts   --coverage",
+    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit --coverage",
     "test:unit": "npm run compile && npm run unit",
     "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
     "compile": "./node_modules/.bin/tsc",

--- a/src/package.json
+++ b/src/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.21"
   },
   "scripts": {
-    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit   --coverage",
+    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit/services/YotiCallbackProcessor.test.ts   --coverage",
     "test:unit": "npm run compile && npm run unit",
     "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
     "compile": "./node_modules/.bin/tsc",

--- a/src/services/GenerateVerifiableCredential.ts
+++ b/src/services/GenerateVerifiableCredential.ts
@@ -1,0 +1,371 @@
+/* eslint-disable no-console */
+import { Logger } from "@aws-lambda-powertools/logger";
+import { AppError } from "../utils/AppError";
+import { HttpCodesEnum } from "../utils/HttpCodesEnum";
+import { YotiDocumentTypesEnum, YOTI_CHECKS, YotiSessionDocument } from "../utils/YotiPayloadEnums";
+import {
+	VerifiedCredentialEvidence,
+	VerifiedCredentialSubject,
+} from "../utils/IVeriCredential";
+
+export class GenerateVerifiableCredential {
+  readonly logger: Logger;
+
+  private static instance: GenerateVerifiableCredential;
+
+  constructor(logger: Logger) {
+  	this.logger = logger;
+  }
+
+  static getInstance(logger: Logger): GenerateVerifiableCredential {
+  	if (!GenerateVerifiableCredential.instance) {
+  		GenerateVerifiableCredential.instance = new GenerateVerifiableCredential(
+  			logger,
+  		);
+  	}
+  	return GenerateVerifiableCredential.instance;
+  }
+
+  private doesDocumentContainValidChip(documentType: string, documentAuthenticityCheckBreakdown: any): boolean {
+  	const validDocumentTypes = ["PASSPORT", "NATIONAL_ID"];
+	
+  	if (validDocumentTypes.includes(documentType)) {
+  		const validChip = documentAuthenticityCheckBreakdown.some(
+  			(subCheck: { sub_check: string; result: string }) =>
+  				subCheck.sub_check === YotiSessionDocument.CHIP_CSCA_TRUSTED && subCheck.result === YotiSessionDocument.SUBCHECK_PASS,
+  		);
+	
+  		return validChip;
+  	}
+	
+  	return false;
+  }
+	
+
+  private calculateStrengthScore(documentType: string, issuingCountry: string, documentContainsValidChip: boolean): number {
+  	if (issuingCountry === "GBR") {
+			switch (documentType) {
+				case "PASSPORT":
+					return documentContainsValidChip ? 4 : 3;
+				case YotiDocumentTypesEnum.UKPHOTOCARDDL:
+						return 3;
+				default:
+					throw new AppError(HttpCodesEnum.SERVER_ERROR, "Invalid documentType provided for issuingCountry", {
+						documentType, issuingCountry,
+					});
+			}
+		}
+		switch (documentType) {
+			case YotiDocumentTypesEnum.NONUKPASSPORT:
+  			return 3;
+			case YotiDocumentTypesEnum.EUPHOTOCARDDL:
+  			return 3;
+			case YotiDocumentTypesEnum.EEAIDENTITYCARD:
+				return documentContainsValidChip ? 4 : 3;
+			case YotiDocumentTypesEnum.BRP:
+				return 4;
+  		default:
+  			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Invalid documentType provided", {
+  				documentType,
+  			});
+  	}
+  }
+	
+
+  private calculateValidityScore(
+  	authenticityRecommendation: string,
+  	documentContainsValidChip: boolean,
+  ): number {
+  	if (authenticityRecommendation === YotiSessionDocument.APPROVE) {
+  		return documentContainsValidChip ? 3 : 2;
+  	}
+  	return 0;
+  }
+	
+  private calculateVerificationProcessLevel(faceMatchCheck: string): number {
+  	return faceMatchCheck === YotiSessionDocument.APPROVE ? 3 : 0;
+  }
+	
+  private getCounterIndicator(
+  	ID_DOCUMENT_FACE_MATCH_RECOMMENDATION: any,
+  	ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION: any,
+  	IBV_VISUAL_REVIEW_CHECK_RECOMMENDATION?: any,
+  	DOCUMENT_SCHEME_VALIDITY_CHECK_RECOMMENDATION?: any,
+  	PROFILE_DOCUMENT_MATCH_RECOMMENDATION?: any,
+  ): any {
+  	const ci: string[] = [];
+	
+  	const addToCI = (code: string | string[]) => {
+  		if (Array.isArray(code)) {
+  			ci.push(...code);
+  		} else {
+  			ci.push(code);
+  		}
+  	};
+	
+  	const handleFaceMatchRejection = () => {
+  		const { value, reason } = ID_DOCUMENT_FACE_MATCH_RECOMMENDATION;
+  		if (value === "REJECT") {
+  			switch (reason) {
+  				case "FACE_NOT_GENUINE":
+  				case "LARGE_AGE_GAP":
+  				case "PHOTO_OF_MASK":
+  				case "PHOTO_OF_PHOTO":
+  				case "DIFFERENT_PERSON":
+  					addToCI("V01");
+  					break;
+  				default:
+  					break;
+  			}
+  		}
+  	};
+	
+  	const handleAuthenticityRejection = () => {
+  		const { value, reason } = ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION;
+  		if (value === "REJECT") {
+  			switch (reason) {
+  				case "COUNTERFEIT":
+  					addToCI("D14");
+  					break;
+  				case "EXPIRED_DOCUMENT":
+  					addToCI("D16");
+  					break;
+  				case "FRAUD_LIST_MATCH":
+  					addToCI(["F03", "D14"]);
+  					break;
+  				case "DOC_NUMBER_INVALID":
+  					addToCI("D02");
+  					break;
+  				case "TAMPERED":
+  				case "DATA_MISMATCH":
+  				case "CHIP_DATA_INTEGRITY_FAILED":
+  				case "CHIP_SIGNATURE_VERIFICATION_FAILED":
+  				case "CHIP_CSCA_VERIFICATION_FAILED":
+  					addToCI("D14");
+  					break;
+  				default:
+  					break;
+  			}
+  		}
+  	};
+	
+  	handleFaceMatchRejection();
+  	handleAuthenticityRejection();
+	
+  	return ci;
+  }
+
+  private attachPersonName(
+  	credentialSubject: VerifiedCredentialSubject,
+  	givenName: string,
+  	familyName: string,
+  ): VerifiedCredentialSubject {
+  	const givenNames = givenName.split(" ");
+  	const nameParts = givenNames.map((name) => ({ value: name, type: "GivenName" }));
+	
+  	nameParts.push({ value: familyName, type: "FamilyName" });
+	
+  	credentialSubject.name = [{ nameParts }];
+	
+  	return credentialSubject;
+  }
+
+  private attachDOB(
+  	credentialSubject: VerifiedCredentialSubject,
+  	dateOfBirth: string,
+  ): VerifiedCredentialSubject {
+  	credentialSubject.birthDate = [{ value: dateOfBirth }];
+	
+  	return credentialSubject;
+  }
+	
+
+  private attachAddressInfo(
+  	credentialSubject: VerifiedCredentialSubject,
+  	postalAddress: any,
+  ): VerifiedCredentialSubject {
+  	credentialSubject.address = [
+  		{
+  			buildingNumber: postalAddress.building_number,
+  			addressLocality: postalAddress.town_city,
+  			postalCode: postalAddress.postal_code,
+  			addressCountry: postalAddress.country,
+  		},
+  	];
+	
+  	return credentialSubject;
+  }
+
+  private attachEvidencePayload(
+  	credentialSubject: VerifiedCredentialSubject,
+  	documentType: string,
+  	documentFields: any,
+  ): VerifiedCredentialSubject {
+  	switch (documentType) {
+  		case YotiDocumentTypesEnum.UKPHOTOCARDDL:
+  			credentialSubject.drivingPermit = [
+  				{
+  					personalNumber: documentFields.document_number,
+  					expiryDate: documentFields.expiration_date,
+  					issueDate: documentFields.date_of_issue,
+  					issueNumber: null,
+  					issuedBy: documentFields.issuing_authority,
+  					fullAddress: documentFields.formatted_address,
+  				},
+  			];
+  			break;
+  		case YotiDocumentTypesEnum.UKPASSPORT:
+  			credentialSubject.passport = [
+  				{
+  					documentNumber: documentFields.document_number,
+  					expiryDate: documentFields.expiration_date,
+  					icaoIssuerCode: documentFields.issuing_country,
+  				},
+  			];
+  			break;
+  		default:
+  			throw new AppError(
+  				HttpCodesEnum.SERVER_ERROR,
+  				"Invalid documentType provided: " + documentType,
+  			);
+  	}
+	
+  	return credentialSubject;
+  }
+	
+
+  getVerifiedCredentialInformation(this: any, 
+  	yotiSessionId: string,
+  	completedYotiSessionPayload: any,
+  	documentFields: any,
+  ): {
+  		credentialSubject: VerifiedCredentialSubject;
+  		evidence: VerifiedCredentialEvidence;
+  	} {
+  	const { id_documents: idDocuments } = completedYotiSessionPayload.resources;
+  	const { checks } = completedYotiSessionPayload;
+  	const documentType = idDocuments[0].document_type;
+		const yotiCountryCode = idDocuments[0].issuing_country;
+
+
+		// const documentType = idDocuments[0].document_type;
+	
+  	const findCheck = (type: string) =>
+  		checks.find((checkCompleted: { type: string }) => checkCompleted.type === type);
+	
+  	const getCheckObject = (check: { state: any; report: { recommendation: any; breakdown: any } }) => ({
+  		object: check,
+  		state: check.state,
+  		recommendation: check.report.recommendation,
+  		breakdown: check.report.breakdown,
+  	});
+	
+  	const MANDATORY_CHECKS = {
+  		ID_DOCUMENT_AUTHENTICITY: findCheck(YOTI_CHECKS.ID_DOCUMENT_AUTHENTICITY.type) ? getCheckObject(findCheck(YOTI_CHECKS.ID_DOCUMENT_AUTHENTICITY.type)) : null,
+  		ID_DOCUMENT_FACE_MATCH: findCheck(YOTI_CHECKS.ID_DOCUMENT_FACE_MATCH.type) ? getCheckObject(findCheck(YOTI_CHECKS.ID_DOCUMENT_FACE_MATCH.type)) : null,
+  		IBV_VISUAL_REVIEW_CHECK: findCheck(YOTI_CHECKS.IBV_VISUAL_REVIEW_CHECK.type) ? getCheckObject(findCheck(YOTI_CHECKS.IBV_VISUAL_REVIEW_CHECK.type)) : null,
+  		DOCUMENT_SCHEME_VALIDITY: findCheck(YOTI_CHECKS.DOCUMENT_SCHEME_VALIDITY_CHECK.type) ? getCheckObject(findCheck(YOTI_CHECKS.DOCUMENT_SCHEME_VALIDITY_CHECK.type)) : null,
+  		PROFILE_DOCUMENT_MATCH: findCheck(YOTI_CHECKS.PROFILE_DOCUMENT_MATCH.type) ? getCheckObject(findCheck(YOTI_CHECKS.PROFILE_DOCUMENT_MATCH.type)) : null,
+  	};
+	
+  	if (Object.values(MANDATORY_CHECKS).some((check) => check?.object === undefined)) {
+  		throw new AppError(
+  			HttpCodesEnum.BAD_REQUEST,
+  			"Missing mandatory checks in Yoti completed payload",
+  			{ MANDATORY_CHECKS },
+  		);
+  	}
+	
+  	if (
+  		Object.values(MANDATORY_CHECKS).some(
+  			(check) => check?.state !== YotiSessionDocument.DONE_STATE,
+  		)
+  	) {
+  		throw new AppError(HttpCodesEnum.BAD_REQUEST, "Mandatory checks not all completed");
+  	}
+	
+  	let credentialSubject: VerifiedCredentialSubject = {};
+	
+  	credentialSubject = this.attachPersonName(
+  		credentialSubject,
+  		documentFields.given_names,
+  		documentFields.family_name,
+  	);
+  	credentialSubject = this.attachDOB(credentialSubject, documentFields.date_of_birth);
+  	if (documentFields.structured_postal_address) {
+  		credentialSubject = this.attachAddressInfo(
+  			credentialSubject,
+  			documentFields.structured_postal_address,
+  	);
+  	}
+  	credentialSubject = this.attachEvidencePayload(
+  		credentialSubject,
+  		documentType,
+  		documentFields,
+  	);
+	
+  	const documentContainsValidChip = this.doesDocumentContainValidChip(
+  		documentType,
+  		MANDATORY_CHECKS.ID_DOCUMENT_AUTHENTICITY?.breakdown,
+  	);
+	
+  	const manualFaceMatchCheck = MANDATORY_CHECKS.ID_DOCUMENT_FACE_MATCH?.breakdown.some(
+  		(subCheck: { sub_check: string; result: string }) =>
+  			subCheck.sub_check === "manual_face_match" &&
+				subCheck.result === YotiSessionDocument.SUBCHECK_PASS,
+  	);
+	
+  	const evidence: VerifiedCredentialEvidence = [
+  		{
+  			type: "IdentityCheck",
+  			strengthScore: this.calculateStrengthScore(documentType, yotiCountryCode, documentContainsValidChip),
+  			validityScore: this.calculateValidityScore(
+  				MANDATORY_CHECKS.ID_DOCUMENT_AUTHENTICITY?.recommendation.value,
+  				documentContainsValidChip,
+  			),
+  			verificationScore: this.calculateVerificationProcessLevel(
+  				MANDATORY_CHECKS.ID_DOCUMENT_FACE_MATCH?.recommendation.value,
+  			),
+  		},
+  	];
+	
+  	if (
+  		evidence[0].strengthScore === 0 ||
+			evidence[0].validityScore === 0 ||
+			evidence[0].verificationScore === 0
+  	) {
+			const counterIndicators = this.getCounterIndicator(MANDATORY_CHECKS.ID_DOCUMENT_FACE_MATCH?.recommendation, MANDATORY_CHECKS.ID_DOCUMENT_AUTHENTICITY?.recommendation);
+			if (counterIndicators.length >= 1) {
+				evidence[0].ci = counterIndicators
+			}
+  		evidence[0].failedCheckDetails = [
+  			{
+  				checkMethod: "vcrypt",
+  				identityCheckPolicy: "published",
+  			},
+  			{
+  				checkMethod: "bvr",
+  				biometricVerificationProcessLevel: 3,
+  			},
+  		];
+  	} else {
+  		evidence[0].checkDetails = [
+  			{
+  				checkMethod: documentContainsValidChip ? "vcrypt" : "vri",
+  				txn: yotiSessionId,
+  				identityCheckPolicy: "published",
+  			},
+  			{
+  				checkMethod: manualFaceMatchCheck ? "pvr" : "bvr",
+  				txn: yotiSessionId,
+  				biometricVerificationProcessLevel: 3,
+  			},
+  		];
+  	}
+	
+  	return {
+  		credentialSubject,
+  		evidence,
+  	};
+  }
+}

--- a/src/services/VerifiableCredentialService.ts
+++ b/src/services/VerifiableCredentialService.ts
@@ -56,7 +56,7 @@ export class VerifiableCredentialService {
   	const subject = sessionItem?.subject as string;
   	const verifiedCredential: VerifiedCredential = this.buildVerifiableCredential(credentialSubject, evidence);
   	const result = {
-  		sub: subject,
+  		sub: `urn:uuid:${subject}`,
   		nbf: now,
   		iss: this.issuer,
   		iat: now,

--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -14,6 +14,7 @@ import { VerifiableCredentialService } from "./VerifiableCredentialService";
 import { KmsJwtAdapter } from "../utils/KmsJwtAdapter";
 import { AuthSessionState } from "../models/enums/AuthSessionState";
 import { GenerateVerifiableCredential } from "./GenerateVerifiableCredential";
+import { YotiSessionDocument } from "../utils/YotiPayloadEnums";
 
 export class YotiCallbackProcessor {
 
@@ -76,7 +77,7 @@ export class YotiCallbackProcessor {
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not found");
   	}
 
-  	if (completedYotiSessionInfo.state !== "COMPLETED") {
+  	if (completedYotiSessionInfo.state !== YotiSessionDocument.COMPLETED) {
   		this.logger.error({ message: "Session in Yoti does not have status COMPLETED" }, { yotiSessionID });
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not complete", { shouldThrow: true });
   	}

--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -66,6 +66,7 @@ export class YotiCallbackProcessor {
   }
 
   async processRequest(eventBody: any): Promise<Response> {
+		//TODO: Check topic of incoming request
   	const yotiSessionID = eventBody.session_id;
 
   	this.logger.info({ message: "Fetching status for Yoti SessionID" }, { yotiSessionID });
@@ -81,6 +82,9 @@ export class YotiCallbackProcessor {
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not complete", { shouldThrow: true });
   	}
 
+		//TODO: Log completedYotiSessionInfo Payload?
+
+		//TODO: Unit Test test
   	const documentFieldsId = completedYotiSessionInfo.resources.id_documents[0].document_fields.media.id;
 
   	if (!documentFieldsId) {
@@ -92,6 +96,8 @@ export class YotiCallbackProcessor {
   		this.logger.error({ message: "No document fields info found" }, { documentFieldsId });
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document fields info not found");
   	}
+
+		//TODO: Log documentFields Payload?
 
   	this.logger.info({ message: "Fetching F2F Session info with Yoti SessionID" }, { yotiSessionID });
   	const f2fSession = await this.f2fService.getSessionByYotiId(yotiSessionID);
@@ -121,6 +127,11 @@ export class YotiCallbackProcessor {
 
   		const { credentialSubject, evidence } =
         this.generateVerifiableCredential.getVerifiedCredentialInformation(yotiSessionID, completedYotiSessionInfo, documentFields);
+
+			if (!credentialSubject || !evidence) {
+				this.logger.error({ message: "Missing Credential Subject or Evidence payload" }, { credentialSubject, evidence });
+				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing Credential Subject or Evidence payload");
+			}
 
   		let signedJWT;
   		try {

--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -66,7 +66,6 @@ export class YotiCallbackProcessor {
   }
 
   async processRequest(eventBody: any): Promise<Response> {
-		//TODO: Check topic of incoming request
   	const yotiSessionID = eventBody.session_id;
 
   	this.logger.info({ message: "Fetching status for Yoti SessionID" }, { yotiSessionID });
@@ -82,9 +81,8 @@ export class YotiCallbackProcessor {
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not complete", { shouldThrow: true });
   	}
 
-		//TODO: Log completedYotiSessionInfo Payload?
+		this.logger.info({ message: "Completed Yoti Session:" }, { completedYotiSessionInfo });
 
-		//TODO: Unit Test test
   	const documentFieldsId = completedYotiSessionInfo.resources.id_documents[0].document_fields.media.id;
 
   	if (!documentFieldsId) {
@@ -97,7 +95,7 @@ export class YotiCallbackProcessor {
   		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document fields info not found");
   	}
 
-		//TODO: Log documentFields Payload?
+		this.logger.info({ message: "Document Fields" }, { documentFields });
 
   	this.logger.info({ message: "Fetching F2F Session info with Yoti SessionID" }, { yotiSessionID });
   	const f2fSession = await this.f2fService.getSessionByYotiId(yotiSessionID);

--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -13,135 +13,162 @@ import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { VerifiableCredentialService } from "./VerifiableCredentialService";
 import { KmsJwtAdapter } from "../utils/KmsJwtAdapter";
 import { AuthSessionState } from "../models/enums/AuthSessionState";
+import { GenerateVerifiableCredential } from "./GenerateVerifiableCredential";
 
 export class YotiCallbackProcessor {
 
-  	private static instance: YotiCallbackProcessor;
+  private static instance: YotiCallbackProcessor;
+	
+  private readonly logger: Logger;
+	
+  private readonly metrics: Metrics;
 
-  	private readonly logger: Logger;
+  private readonly yotiService: YotiService;
 
-  	private readonly metrics: Metrics;
+  private readonly f2fService: F2fService;
 
-  	private readonly yotiService: YotiService;
+  private readonly environmentVariables: EnvironmentVariables;
 
-  	private readonly f2fService: F2fService;
+  private readonly verifiableCredentialService: VerifiableCredentialService;
 
-		private readonly environmentVariables: EnvironmentVariables;
+  private readonly kmsJwtAdapter: KmsJwtAdapter;
 
-		private readonly verifiableCredentialService: VerifiableCredentialService;
+  private readonly generateVerifiableCredential: GenerateVerifiableCredential;
 
-		private readonly kmsJwtAdapter: KmsJwtAdapter;
+  constructor(
+  	logger: Logger,
+  	metrics: Metrics,
+  	YOTI_PRIVATE_KEY: string,
+  ) {
+  	this.logger = logger;
+  	this.metrics = metrics;
+  	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.CALLBACK_SERVICE);
+  	this.yotiService = YotiService.getInstance(this.logger, this.environmentVariables.yotiSdk(), this.environmentVariables.resourcesTtlInSeconds(), this.environmentVariables.clientSessionTokenTtlInSeconds(), YOTI_PRIVATE_KEY, this.environmentVariables.yotiBaseUrl());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.kmsJwtAdapter = new KmsJwtAdapter(this.environmentVariables.kmsKeyArn());
+  	this.verifiableCredentialService = VerifiableCredentialService.getInstance(this.environmentVariables.sessionTable(), this.kmsJwtAdapter, this.environmentVariables.issuer(), this.logger);
+  	this.generateVerifiableCredential = GenerateVerifiableCredential.getInstance(this.logger);
+  }
 
-  	constructor(logger: Logger, metrics: Metrics, YOTI_PRIVATE_KEY: string) {
-  		this.logger = logger;
-  		this.metrics = metrics;
-			this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.CALLBACK_SERVICE);
-			this.yotiService = YotiService.getInstance(this.logger, this.environmentVariables.yotiSdk(), this.environmentVariables.resourcesTtlInSeconds(), this.environmentVariables.clientSessionTokenTtlInSeconds(), YOTI_PRIVATE_KEY, this.environmentVariables.yotiBaseUrl());
-			this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
-			this.kmsJwtAdapter = new KmsJwtAdapter(this.environmentVariables.kmsKeyArn());
-			this.verifiableCredentialService = VerifiableCredentialService.getInstance(this.environmentVariables.sessionTable(), this.kmsJwtAdapter, this.environmentVariables.issuer(), this.logger);
+  static getInstance(
+  	logger: Logger,
+  	metrics: Metrics,
+  	YOTI_PRIVATE_KEY: string,
+  ): YotiCallbackProcessor {
+  	if (!YotiCallbackProcessor.instance) {
+  		YotiCallbackProcessor.instance = new YotiCallbackProcessor(
+  			logger,
+  			metrics,
+  			YOTI_PRIVATE_KEY,
+  		);
+  	}
+  	return YotiCallbackProcessor.instance;
+  }
+
+  async processRequest(eventBody: any): Promise<Response> {
+  	const yotiSessionID = eventBody.session_id;
+
+  	this.logger.info({ message: "Fetching status for Yoti SessionID" }, { yotiSessionID });
+  	const completedYotiSessionInfo = await this.yotiService.getCompletedSessionInfo(yotiSessionID);
+
+  	if (!completedYotiSessionInfo) {
+  		this.logger.error({ message: "No YOTI Session found with ID:" }, { yotiSessionID });
+  		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not found");
   	}
 
-  	static getInstance(
-  		logger: Logger,
-  		metrics: Metrics,
-  		YOTI_PRIVATE_KEY: string,
-  	): YotiCallbackProcessor {
-  		if (!YotiCallbackProcessor.instance) {
-  			YotiCallbackProcessor.instance =
-        new YotiCallbackProcessor(logger, metrics, YOTI_PRIVATE_KEY);
+  	if (completedYotiSessionInfo.state !== "COMPLETED") {
+  		this.logger.error({ message: "Session in Yoti does not have status COMPLETED" }, { yotiSessionID });
+  		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not complete", { shouldThrow: true });
+  	}
+
+  	const documentFieldsId = completedYotiSessionInfo.resources.id_documents[0].document_fields.media.id;
+
+  	if (!documentFieldsId) {
+  		this.logger.error({ message: "No document_fields ID found in completed Yoti Session" }, { yotiSessionID });
+  		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document_fields ID not found");
+  	}
+  	const documentFields = await this.yotiService.getMediaContent(yotiSessionID, documentFieldsId);
+  	if (!documentFields) {
+  		this.logger.error({ message: "No document fields info found" }, { documentFieldsId });
+  		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document fields info not found");
+  	}
+
+  	this.logger.info({ message: "Fetching F2F Session info with Yoti SessionID" }, { yotiSessionID });
+  	const f2fSession = await this.f2fService.getSessionByYotiId(yotiSessionID);
+
+  	if (!f2fSession) {
+  		throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing Info in Session Table");
+  	}
+
+  	// Validate the AuthSessionState to be "F2F_ACCESS_TOKEN_ISSUED"
+  	if (
+  		f2fSession.authSessionState === AuthSessionState.F2F_ACCESS_TOKEN_ISSUED ||
+      f2fSession.authSessionState === AuthSessionState.F2F_AUTH_CODE_ISSUED
+  	) {
+  		try {
+  			await this.f2fService.sendToTXMA({
+  				event_name: "F2F_YOTI_END",
+  				...buildCoreEventFields(
+  					f2fSession,
+  					this.environmentVariables.issuer(),
+  					f2fSession.clientIpAddress,
+  					absoluteTimeNow,
+  				),
+  			});
+  		} catch (error) {
+  			this.logger.error("Failed to write TXMA event F2F_YOTI_END to SQS queue.");
   		}
-  		return YotiCallbackProcessor.instance;
+
+  		const { credentialSubject, evidence } =
+        this.generateVerifiableCredential.getVerifiedCredentialInformation(yotiSessionID, completedYotiSessionInfo, documentFields);
+
+  		let signedJWT;
+  		try {
+  			signedJWT = await this.verifiableCredentialService.generateSignedVerifiableCredentialJwt(f2fSession, credentialSubject, evidence, absoluteTimeNow);
+  		} catch (error) {
+  			if (error instanceof AppError) {
+  				this.logger.error({ message: "Error generating signed verifiable credential jwt: " + error.message });
+  				return new Response(HttpCodesEnum.SERVER_ERROR, "Failed to sign the verifiableCredential Jwt");
+  			}
+  		}
+
+  		if (!signedJWT) {
+  			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unable to create signed JWT");
+  		}
+
+  		try {
+  			await this.f2fService.sendToIPVCore({
+  				sub: f2fSession.subject,
+  				state: f2fSession.state,
+  				"https://vocab.account.gov.uk/v1/credentialJWT": signedJWT,
+  			});
+  		} catch (error) {
+  			this.logger.error({ message: "Failed to send VC to IPV Core Queue" }, { error });
+  			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Failed to send to IPV Core", { shouldThrow: true });
+  		}
+
+  		try {
+  			await this.f2fService.sendToTXMA({
+  				event_name: "F2F_CRI_VC_ISSUED",
+  				...buildCoreEventFields(
+  					f2fSession,
+  					this.environmentVariables.issuer(),
+  					f2fSession.clientIpAddress,
+  					absoluteTimeNow,
+  				),
+  			});
+  		} catch (error) {
+  			this.logger.error("Failed to write TXMA event F2F_CRI_VC_ISSUED to SQS queue.");
+  		}
+
+  		await this.f2fService.updateSessionAuthState(
+  			f2fSession.sessionId,
+  			AuthSessionState.F2F_CREDENTIAL_ISSUED,
+  		);
+
+  		return new Response(HttpCodesEnum.OK, "OK");
+  	} else {
+  		return new Response(HttpCodesEnum.UNAUTHORIZED, `AuthSession is in wrong Auth state: Expected state- ${AuthSessionState.F2F_ACCESS_TOKEN_ISSUED} or ${AuthSessionState.F2F_AUTH_CODE_ISSUED}, actual state- ${f2fSession.authSessionState}`);
   	}
-
-  	async processRequest(eventBody: any): Promise<Response> {
-
-  		const yotiSessionID = eventBody.session_id;
-
-			this.logger.info({ message:"Fetching status for Yoti SessionID" }, { yotiSessionID });
-  		const completedYotiSessionInfo = await this.yotiService.getCompletedSessionInfo(yotiSessionID);
-
-			if (!completedYotiSessionInfo) {
-				//TODO: Throw alarm here
-				this.logger.error({ message:"No YOTI Session found with ID:" }, { yotiSessionID });
-				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not found");
-		 }
-
-			if (completedYotiSessionInfo.state !== "COMPLETED") {
-				this.logger.error({ message:"Session in Yoti does not have status COMPLETED" }, { yotiSessionID });
-				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti Session not complete", { shouldThrow: true });
-		 }
-
-		 this.logger.info({ message:"Fetching F2F Session info with Yoti SessionID" }, { yotiSessionID });
-		 const f2fSession = await this.f2fService.getSessionByYotiId(yotiSessionID);
-
-		 if (!f2fSession) {
-				//TODO: Throw alarm here
-				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing Info in Session Table");
-		 }
-
-		 const f2fSessionId = f2fSession.sessionId;
-		 const f2fIndentityInfo = await this.f2fService.getPersonIdentityById(f2fSessionId, this.environmentVariables.personIdentityTableName());
-
-		 if (!f2fIndentityInfo) {
-				//TODO: Throw alarm here
-				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing Info in Person Identity Table");
-			}
-
-			// Validate the AuthSessionState to be "F2F_ACCESS_TOKEN_ISSUED"
-			if (f2fSession.authSessionState === AuthSessionState.F2F_ACCESS_TOKEN_ISSUED ||
-				f2fSession.authSessionState === AuthSessionState.F2F_AUTH_CODE_ISSUED) {
-
-
-				try {
-					await this.f2fService.sendToTXMA({
-						event_name: "F2F_YOTI_END",
-						...buildCoreEventFields(f2fSession, this.environmentVariables.issuer(), f2fSession.clientIpAddress, absoluteTimeNow),
-					});
-				} catch (error) {
-					this.logger.error("Failed to write TXMA event F2F_YOTI_END to SQS queue.");
-				}
-
-				let signedJWT;
-				try {
-					signedJWT = await this.verifiableCredentialService.generateSignedVerifiableCredentialJwt(f2fSession, f2fIndentityInfo, absoluteTimeNow);
-				} catch (error) {
-					if (error instanceof AppError) {
-						this.logger.error({ message: "Error generating signed verifiable credential jwt: " + error.message });
-						return new Response(HttpCodesEnum.SERVER_ERROR, "Failed to sign the verifiableCredential Jwt");
-					}
-				}
-
-				if (!signedJWT) {
-				//TODO: Throw alarm here
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unable to create signed JWT");
-				}
-
-				try {
-					await this.f2fService.sendToIPVCore({
-						sub: f2fSession.subject,
-						state: f2fSession.state,
-						"https://vocab.account.gov.uk/v1/credentialJWT": signedJWT,
-					});
-				} catch (error) {
-					this.logger.error({ message: "Failed to send VC to IPV Core Queue" }, { error });
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, "Failed to send to IPV Core", { shouldThrow: true });
-				}
-
-				try {
-					await this.f2fService.sendToTXMA({
-						event_name: "F2F_CRI_VC_ISSUED",
-						...buildCoreEventFields(f2fSession, this.environmentVariables.issuer(), f2fSession.clientIpAddress, absoluteTimeNow),
-					});
-				} catch (error) {
-					this.logger.error("Failed to write TXMA event F2F_CRI_VC_ISSUED to SQS queue.");
-				}
-
-				await this.f2fService.updateSessionAuthState(f2fSession.sessionId, AuthSessionState.F2F_CREDENTIAL_ISSUED);
-
-				return new Response(HttpCodesEnum.OK, "OK");
-			} else {
-				return new Response(HttpCodesEnum.UNAUTHORIZED, `AuthSession is in wrong Auth state: Expected state- ${AuthSessionState.F2F_ACCESS_TOKEN_ISSUED} or ${AuthSessionState.F2F_AUTH_CODE_ISSUED}, actual state- ${f2fSession.authSessionState}`);
-			}
-  	}
+  }
 }

--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -7,7 +7,7 @@ import { HttpCodesEnum } from "../utils/HttpCodesEnum";
 import { HttpVerbsEnum } from "../utils/HttpVerbsEnum";
 import { PersonIdentityItem } from "../models/PersonIdentityItem";
 import { ApplicantProfile, PostOfficeInfo, YotiSessionInfo, CreateSessionPayload, YotiCompletedSession } from "../models/YotiPayloads";
-import { YotiDocumentTypesEnum, YOTI_DOCUMENT_COUNTRY_CODE, YOTI_REQUESTED_CHECKS, YOTI_REQUESTED_TASKS, YOTI_SESSION_TOPICS, UK_POST_OFFICE } from "../utils/YotiPayloadEnums";
+import { YotiDocumentTypesEnum, YOTI_REQUESTED_CHECKS, YOTI_REQUESTED_TASKS, YOTI_SESSION_TOPICS, UK_POST_OFFICE } from "../utils/YotiPayloadEnums";
 import { personIdentityUtils } from "../utils/PersonIdentityUtils";
 
 export class YotiService {

--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -124,9 +124,8 @@ export class YotiService {
 		personDetails: PersonIdentityItem,
 		selectedDocument: string,
 		countryCode: string,
-		YOTICALLBACKURL?: string,
+		yotiCallbackUrl: string,
 	): Promise<string | undefined> {
-		//TODO: YOTICALLBACKURL needs updating in template.yaml file within deploy folders oncer we have work completed on return journey
 		this.logger.info("SELECTED DOCUMENT - YotiService START", selectedDocument);
 		this.logger.info("COUNTRY CODE - YotiService START", countryCode);
 		const payloadJSON: CreateSessionPayload = {
@@ -137,7 +136,7 @@ export class YotiService {
 			},
 			user_tracking_id: personDetails.sessionId,
 			notifications: {
-				endpoint: YOTICALLBACKURL ? YOTICALLBACKURL : "",
+				endpoint: yotiCallbackUrl,
 				topics: YOTI_SESSION_TOPICS,
 				auth_token: "string",
 				auth_type: "BASIC",
@@ -294,6 +293,22 @@ export class YotiService {
 		} catch (err) {
 			this.logger.error({ message: "An error occurred when fetching Yoti session ", err });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error fetching Yoti Session");
+		}
+	}
+
+	async getMediaContent(sessionId: string, mediaId: string): Promise<any | undefined> {
+		const yotiRequest = this.generateYotiRequest({
+			method: HttpVerbsEnum.GET,
+			endpoint: `/sessions/${sessionId}/media/${mediaId}/content`,
+		});
+
+		try {
+			const { data } = await axios.get(yotiRequest.url, yotiRequest.config);
+
+			return data;
+		} catch (err) {
+			this.logger.error({ message: "An error occurred when fetching Yoti media content", err });
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error fetching Yoti media content");
 		}
 	}
 }

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -1,7 +1,7 @@
 import yotiRequestData from "../data/yotiSessionsPayloadValid.json";
 import { postYotiSession, getYotiSessionsConfiguration, putYotiSessionsInstructions, getYotiSessionsInstructions } from "../utils/ApiTestSteps";
 
-describe.skip("Yoti /sessions endpoint", () => {
+describe("Yoti /sessions endpoint", () => {
 
 	//responseCode, user_tracking_ui
 	const postSessionsParams = [

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -1,7 +1,7 @@
 import yotiRequestData from "../data/yotiSessionsPayloadValid.json";
 import { postYotiSession, getYotiSessionsConfiguration, putYotiSessionsInstructions, getYotiSessionsInstructions } from "../utils/ApiTestSteps";
 
-describe("Yoti /sessions endpoint", () => {
+describe.skip("Yoti /sessions endpoint", () => {
 
 	//responseCode, user_tracking_ui
 	const postSessionsParams = [

--- a/src/tests/unit/YotiCallbackHandler.test.ts
+++ b/src/tests/unit/YotiCallbackHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../YotiCallbackHandler";
 import { YotiCallbackProcessor } from "../../services/YotiCallbackProcessor";
-import { VALID_SQS_EVENT } from "./data/sqs-events";
+import { VALID_SQS_EVENT } from "./data/callback-events";
 import { HttpCodesEnum } from "../../utils/HttpCodesEnum";
 import { AppError } from "../../utils/AppError";
 

--- a/src/tests/unit/data/callback-events.ts
+++ b/src/tests/unit/data/callback-events.ts
@@ -1,0 +1,23 @@
+export const VALID_SQS_EVENT = {
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": "{\"sessionId\":\"eb26c8e0-397b-4f5e-b7a5-62cd0c6e510b\",\"yotiSessionId\":\"8fbbe7bf-3ce6-4dc0-b4f3-b36d4684c6bc\",\"topic\":\"session_completion\"}",
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
+}
+;

--- a/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
+++ b/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
@@ -161,7 +161,7 @@ function getYotiSessionInfo(): YotiSessionInfo {
 }
 
 describe("DocumentSelectionRequestProcessor", () => {
-	let personIdentityItem: PersonIdentityItem, f2fSessionItem: ISessionItem, f2fSessionItemInvalid: ISessionItem, yotiSessionInfo: YotiSessionInfo;
+	let personIdentityItem: PersonIdentityItem, f2fSessionItem: ISessionItem, yotiSessionInfo: YotiSessionInfo;
 	beforeAll(() => {
 		mockDocumentSelectionRequestProcessor = new DocumentSelectionRequestProcessor(logger, metrics, "YOTIPRIM");
 		// @ts-ignore
@@ -260,7 +260,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 	});
 
 	it("Throw server error if Yoti Session already exists", async () => {
-		const f2fSessionItemInvalid = {
+		const f2fSessionItemInvalid: ISessionItem = {
 			...f2fSessionItem,
 			authSessionState: AuthSessionState.F2F_YOTI_SESSION_CREATED,
 			yotiSessionId: "RandomYOTISessionID",

--- a/src/tests/unit/services/GenerateVerifiableCredential.test.ts
+++ b/src/tests/unit/services/GenerateVerifiableCredential.test.ts
@@ -305,19 +305,19 @@ describe("GenerateVerifiableCredential", () => {
 			const result = generateVerifiableCredential["attachEvidencePayload"](
 				credentialSubject,
 				documentType,
+				"GBR",
 				documentFields,
 			);
 
 			expect(result).toEqual({
 				drivingPermit: [
 					{
-						personalNumber: "BOEJJ861281TP9DH",
-						expiryDate: "2025-01-01",
-						issueDate: "2020-01-01",
-						issueNumber: null,
-						issuedBy: "Authority",
-						fullAddress: "Address",
-					},
+						personalNumber: 'BOEJJ861281TP9DH',
+						expiryDate: '2025-01-01',
+						issueDate: '2020-01-01',
+						issuedBy: 'Authority',
+						fullAddress: 'Address'
+					}
 				],
 			});
 		});
@@ -334,6 +334,7 @@ describe("GenerateVerifiableCredential", () => {
 			const result = generateVerifiableCredential["attachEvidencePayload"](
 				credentialSubject,
 				documentType,
+				"GBR",
 				documentFields,
 			);
 
@@ -357,6 +358,7 @@ describe("GenerateVerifiableCredential", () => {
 				generateVerifiableCredential["attachEvidencePayload"](
 					credentialSubject,
 					documentType,
+					"GBR",
 					documentFields,
 				),
 			).toThrow("Invalid documentType provided");
@@ -482,7 +484,7 @@ describe("GenerateVerifiableCredential", () => {
 								"txn":"yoti-session-id",
 								 },
 								 {
-								"biometricVerificationProcessLevel":3,
+								"photoVerificationProcessLevel":3,
 								"checkMethod":"pvr",
 								"txn":"yoti-session-id",
 								 },

--- a/src/tests/unit/services/GenerateVerifiableCredential.test.ts
+++ b/src/tests/unit/services/GenerateVerifiableCredential.test.ts
@@ -187,7 +187,7 @@ describe("GenerateVerifiableCredential", () => {
 		});
 	});
 
-	describe("getCounterIndicator", () => {
+	describe("getContraIndicator", () => {
 		it("should return the correct counter indicators for face match rejection reason 'FACE_NOT_GENUINE'", () => {
 			const ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION = {
 				value: "APPROVE",
@@ -197,12 +197,9 @@ describe("GenerateVerifiableCredential", () => {
 				reason: "FACE_NOT_GENUINE",
 			};
 
-			const result = generateVerifiableCredential["getCounterIndicator"](
+			const result = generateVerifiableCredential["getContraIndicator"](
 				ID_DOCUMENT_FACE_MATCH_RECOMMENDATION,
 				ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION,
-				null,
-				null,
-				null,
 			);
 
 			expect(result).toEqual(["V01"]);
@@ -217,12 +214,9 @@ describe("GenerateVerifiableCredential", () => {
 				value: "APPROVE",
 			};
 
-			const result = generateVerifiableCredential["getCounterIndicator"](
+			const result = generateVerifiableCredential["getContraIndicator"](
 				ID_DOCUMENT_FACE_MATCH_RECOMMENDATION,
 				ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION,
-				null,
-				null,
-				null,
 			);
 
 			expect(result).toEqual([]);
@@ -269,6 +263,7 @@ describe("GenerateVerifiableCredential", () => {
 		it("should attach the address information to the credential subject", () => {
 			const credentialSubject = {};
 			const postalAddress = {
+				address_line1: "122 BURNS CRESCENT",
 				building_number: "123",
 				town_city: "City",
 				postal_code: "12345",
@@ -284,6 +279,7 @@ describe("GenerateVerifiableCredential", () => {
 						addressLocality: "City",
 						postalCode: "12345",
 						addressCountry: "Country",
+						streetName: "BURNS CRESCENT",
 					},
 				],
 			});
@@ -295,6 +291,9 @@ describe("GenerateVerifiableCredential", () => {
 			const credentialSubject = {};
 			const documentType = "DRIVING_LICENCE";
 			const documentFields = {
+				given_names: "Joe",
+				family_name: "Blog",
+				date_of_birth: "01-01-2010",
 				document_number: "BOEJJ861281TP9DH",
 				expiration_date: "2025-01-01",
 				date_of_issue: "2020-01-01",
@@ -326,6 +325,9 @@ describe("GenerateVerifiableCredential", () => {
 			const credentialSubject = {};
 			const documentType = "PASSPORT";
 			const documentFields = {
+				given_names: "Joe",
+				family_name: "Blog",
+				date_of_birth: "01-01-2010",
 				document_number: "123456789",
 				expiration_date: "2025-01-01",
 				issuing_country: "GBR",
@@ -352,7 +354,11 @@ describe("GenerateVerifiableCredential", () => {
 		it("should throw an error for an invalid document type", () => {
 			const credentialSubject = {};
 			const documentType = "INVALID_DOCUMENT";
-			const documentFields = {};
+			const documentFields = {
+				given_names: "Joe",
+				family_name: "Blog",
+				date_of_birth: "01-01-2010",
+			};
 
 			expect(() =>
 				generateVerifiableCredential["attachEvidencePayload"](
@@ -368,70 +374,278 @@ describe("GenerateVerifiableCredential", () => {
 	describe("getVerifiedCredentialInformation", () => {
 		const mockYotiSessionId = "yoti-session-id";
 		const mockCompletedYotiSessionPayload = {
-			resources: {
-				id_documents: [
-					{
-						document_type: "PASSPORT",
-					},
-				],
-			},
-			checks: [
-				{
-					type: "ID_DOCUMENT_AUTHENTICITY",
-					state: "DONE",
-					report: {
-						recommendation: {
-							value: "APPROVE",
-						},
-						breakdown: [],
-					},
-				},
-				{
-					type: "ID_DOCUMENT_FACE_MATCH",
-					state: "DONE",
-					report: {
-						recommendation: {
-							value: "APPROVE",
-						},
-						breakdown: [
+			"client_session_token_ttl": 2209195,
+			"session_id": "87a7b98e-b4d0-4670-9819-e5288642eddb",
+			"state": "COMPLETED",
+			"resources": {
+					"id_documents": [
 							{
-								sub_check: "manual_face_match",
-								result: "PASS",
+									"id": "b2a71a45-3c5a-4a6c-9246-c05356f6260c",
+									"tasks": [
+											{
+													"type": "ID_DOCUMENT_TEXT_DATA_EXTRACTION",
+													"id": "a20bbcab-223b-433a-a9a7-2a347a29f6bb",
+													"state": "DONE",
+													"created": "2023-04-11T10:17:40Z",
+													"last_updated": "2023-04-11T10:18:37Z",
+													"generated_checks": [],
+													"generated_media": [
+															{
+																	"id": "01a7ac11-fe73-4991-b188-4914f2011d1a",
+																	"type": "JSON"
+															}
+													]
+											}
+									],
+									"source": {
+											"type": "IBV"
+									},
+									"created_at": "2023-04-11T10:17:40Z",
+									"last_updated": "2023-04-11T10:18:37Z",
+									"document_type": "PASSPORT",
+									"issuing_country": "GBR",
+									"pages": [
+											{
+													"capture_method": "CAMERA",
+													"media": {
+															"id": "3f477902-e517-4ead-9131-3129fbb64845",
+															"type": "IMAGE",
+															"created": "2023-04-11T10:18:25Z",
+															"last_updated": "2023-04-11T10:18:25Z"
+													},
+													"frames": [
+															{
+																	"media": {
+																			"id": "b5fbda3b-b2be-48d6-b6a7-6120198519f0",
+																			"type": "IMAGE",
+																			"created": "2023-04-11T10:18:27Z",
+																			"last_updated": "2023-04-11T10:18:27Z"
+																	}
+															},
+															{
+																	"media": {
+																			"id": "888b57a4-3fdc-47d1-9655-a5bc3114c179",
+																			"type": "IMAGE",
+																			"created": "2023-04-11T10:18:29Z",
+																			"last_updated": "2023-04-11T10:18:29Z"
+																	}
+															},
+															{
+																	"media": {
+																			"id": "58c2fc48-ab4f-4737-a57b-f577e9964b69",
+																			"type": "IMAGE",
+																			"created": "2023-04-11T10:18:31Z",
+																			"last_updated": "2023-04-11T10:18:31Z"
+																	}
+															}
+													]
+											}
+									],
+									"document_fields": {
+											"media": {
+													"id": "01a7ac11-fe73-4991-b188-4914f2011d1a",
+													"type": "JSON",
+													"created": "2023-04-11T10:18:36Z",
+													"last_updated": "2023-04-11T10:18:36Z"
+											}
+									},
+									"document_id_photo": {
+											"media": {
+													"id": "0f9a5e39-476d-48d3-9eb4-c66342a2916e",
+													"type": "IMAGE",
+													"created": "2023-04-11T10:18:36Z",
+													"last_updated": "2023-04-11T10:18:36Z"
+											}
+									}
+							}
+					],
+					"supplementary_documents": [],
+					"liveness_capture": [],
+					"face_capture": [
+							{
+									"id": "4b6eb8a9-882f-4ae4-a10f-26b57ff5a328",
+									"tasks": [],
+									"source": {
+											"type": "IBV"
+									},
+									"created_at": "2023-04-11T10:18:45Z",
+									"last_updated": "2023-04-11T10:19:16Z",
+									"image": {
+											"media": {
+													"id": "d8285306-7d47-47b9-b964-df2d668ba013",
+													"type": "IMAGE",
+													"created": "2023-04-11T10:19:16Z",
+													"last_updated": "2023-04-11T10:19:16Z"
+											}
+									}
+							}
+					],
+					"applicant_profiles": [
+							{
+									"id": "a2c78800-fc3c-4104-808c-70de5285b916",
+									"tasks": [],
+									"source": {
+											"type": "RELYING_BUSINESS"
+									},
+									"created_at": "2023-04-11T10:16:33Z",
+									"last_updated": "2023-04-11T10:16:33Z",
+									"media": {
+											"id": "1a30b3a4-83a1-4493-a796-1dd000041cb5",
+											"type": "JSON",
+											"created": "2023-04-11T10:16:33Z",
+											"last_updated": "2023-04-11T10:16:33Z"
+									}
+							}
+					]
+			},
+			"checks": [
+					{
+							"type": "ID_DOCUMENT_AUTHENTICITY",
+							"id": "1b97f98a-7ec8-49b4-8054-719592f04db3",
+							"state": "DONE",
+							"resources_used": [
+									"b2a71a45-3c5a-4a6c-9246-c05356f6260c"
+							],
+							"generated_media": [],
+							"report": {
+									"recommendation": {
+											"value": "APPROVE"
+									},
+									"breakdown": [
+											{
+													"sub_check": "chip_csca_trusted",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "chip_data_integrity",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "chip_digital_signature_verification",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "chip_parse",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "chip_sod_parse",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "document_in_date",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "fraud_list_check",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "mrz_validation",
+													"result": "PASS",
+													"details": []
+											},
+											{
+													"sub_check": "ocr_mrz_comparison",
+													"result": "PASS",
+													"details": []
+											}
+									]
 							},
-						],
+							"created": "2023-04-11T10:19:29Z",
+							"last_updated": "2023-04-11T10:19:30Z"
 					},
-				},
-				{
-					type: "IBV_VISUAL_REVIEW_CHECK",
-					state: "DONE",
-					report: {
-						recommendation: {
-							value: "APPROVE",
-						},
-						breakdown: [],
+					{
+							"type": "ID_DOCUMENT_FACE_MATCH",
+							"id": "62d20daa-1c6f-4558-8381-2d9c7f8a73d5",
+							"state": "DONE",
+							"resources_used": [
+									"b2a71a45-3c5a-4a6c-9246-c05356f6260c",
+									"4b6eb8a9-882f-4ae4-a10f-26b57ff5a328"
+							],
+							"generated_media": [],
+							"report": {
+									"recommendation": {
+											"value": "APPROVE"
+									},
+									"breakdown": [
+											{
+													"sub_check": "ai_face_match",
+													"result": "PASS",
+													"details": [
+															{
+																	"name": "confidence_score",
+																	"value": "0.95"
+															}
+													]
+											}
+									]
+							},
+							"created": "2023-04-11T10:19:29Z",
+							"last_updated": "2023-04-11T10:19:31Z"
 					},
-				},
-				{
-					type: "DOCUMENT_SCHEME_VALIDITY_CHECK",
-					state: "DONE",
-					report: {
-						recommendation: {
-							value: "APPROVE",
-						},
-						breakdown: [],
+					{
+							"type": "IBV_VISUAL_REVIEW_CHECK",
+							"id": "7dce5f7f-6e63-4472-a77d-30fe4aaf142f",
+							"state": "DONE",
+							"resources_used": [
+									"b2a71a45-3c5a-4a6c-9246-c05356f6260c"
+							],
+							"generated_media": [],
+							"report": {
+									"recommendation": {
+											"value": "APPROVE"
+									},
+									"breakdown": []
+							},
+							"created": "2023-04-11T10:19:29Z",
+							"last_updated": "2023-04-11T10:19:29Z"
 					},
-				},
-				{
-					type: "PROFILE_DOCUMENT_MATCH",
-					state: "DONE",
-					report: {
-						recommendation: {
-							value: "APPROVE",
-						},
-						breakdown: [],
+					{
+							"type": "DOCUMENT_SCHEME_VALIDITY_CHECK",
+							"id": "24eb03f3-9768-42df-82bf-f3d26869e579",
+							"state": "DONE",
+							"resources_used": [
+									"b2a71a45-3c5a-4a6c-9246-c05356f6260c"
+							],
+							"generated_media": [],
+							"report": {
+									"recommendation": {
+											"value": "APPROVE"
+									},
+									"breakdown": []
+							},
+							"created": "2023-04-11T10:19:29Z",
+							"last_updated": "2023-04-11T10:19:29Z",
+							"scheme": "UK_GDS"
 					},
-				},
+					{
+							"type": "PROFILE_DOCUMENT_MATCH",
+							"id": "124211f6-f41c-435e-b6aa-33ba9153cbab",
+							"state": "DONE",
+							"resources_used": [
+									"b2a71a45-3c5a-4a6c-9246-c05356f6260c",
+									"a2c78800-fc3c-4104-808c-70de5285b916"
+							],
+							"generated_media": [],
+							"report": {
+									"recommendation": {
+											"value": "APPROVE"
+									},
+									"breakdown": []
+							},
+							"created": "2023-04-11T10:19:29Z",
+							"last_updated": "2023-04-11T10:19:29Z"
+					}
 			],
+			"user_tracking_id": "some_id2"
 		};
 		const mockDocumentFields = {
 			given_names: "John",
@@ -449,57 +663,57 @@ describe("GenerateVerifiableCredential", () => {
 			expect(result).toEqual({
 				"credentialSubject":{
 					 "birthDate":[
-						{
-								 "value":"1990-01-01",
-						},
+							{
+								 "value":"1990-01-01"
+							}
 					 ],
 					 "name":[
-						{
+							{
 								 "nameParts":[
-								{
+										{
 											 "type":"GivenName",
-											 "value":"John",
-								},
-								{
+											 "value":"John"
+										},
+										{
 											 "type":"FamilyName",
-											 "value":"Doe",
-								},
-								 ],
-						},
+											 "value":"Doe"
+										}
+								 ]
+							}
 					 ],
 					 "passport":[
-						{
+							{
 								 "documentNumber":undefined,
 								 "expiryDate":undefined,
-								 "icaoIssuerCode":undefined,
-						},
-					 ],
+								 "icaoIssuerCode":undefined
+							}
+					 ]
 				},
 				"evidence":[
 					 {
-						"checkDetails":[
+							"checkDetails":[
 								 {
-								"checkMethod":"vri",
-								"identityCheckPolicy":"published",
-								"txn":"yoti-session-id",
+										"checkMethod":"vcrypt",
+										"identityCheckPolicy":"published",
+										"txn":"yoti-session-id"
 								 },
 								 {
-								"photoVerificationProcessLevel":3,
-								"checkMethod":"pvr",
-								"txn":"yoti-session-id",
-								 },
-						],
-						"strengthScore":3,
-						"type":"IdentityCheck",
-						"validityScore":2,
-						"verificationScore":3,
-					 },
-				],
+										"biometricVerificationProcessLevel":3,
+										"checkMethod":"bvr",
+										"txn":"yoti-session-id"
+								 }
+							],
+							"strengthScore":4,
+							"type":"IdentityCheck",
+							"validityScore":3,
+							"verificationScore":3
+					 }
+				]
 		 });
 		});
 
 		it("should throw an error when mandatory checks are missing", () => {
-			const incompletePayload = {
+			const incompletePayload: any = {
 				resources: {
 					id_documents: [
 						{
@@ -532,7 +746,7 @@ describe("GenerateVerifiableCredential", () => {
 		});
 
 		it("should throw an error when mandatory checks are not all completed", () => {
-			const incompletePayload = {
+			const incompletePayload: any = {
 				resources: {
 					id_documents: [
 						{

--- a/src/tests/unit/services/GenerateVerifiableCredential.test.ts
+++ b/src/tests/unit/services/GenerateVerifiableCredential.test.ts
@@ -1,0 +1,579 @@
+/* eslint-disable @typescript-eslint/dot-notation */
+import { Logger } from "@aws-lambda-powertools/logger";
+import { GenerateVerifiableCredential } from "../../../services/GenerateVerifiableCredential";
+
+describe("GenerateVerifiableCredential", () => {
+	let logger: Logger;
+	let generateVerifiableCredential: GenerateVerifiableCredential;
+
+	beforeEach(() => {
+		logger = new Logger();
+		generateVerifiableCredential = GenerateVerifiableCredential.getInstance(logger);
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe("doesDocumentContainValidChip", () => {
+		it("should return true if document type is valid and contains a valid chip", () => {
+			const documentType = "PASSPORT";
+			const documentAuthenticityCheckBreakdown = [
+				{
+					sub_check: "chip_csca_trusted",
+					result: "PASS",
+				},
+			];
+
+			const result = generateVerifiableCredential["doesDocumentContainValidChip"](
+				documentType,
+				documentAuthenticityCheckBreakdown,
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it("should return false if document type is not valid", () => {
+			const documentType = "INVALID_DOCUMENT";
+			const documentAuthenticityCheckBreakdown = [
+				{
+					sub_check: "chip_csca_trusted",
+					result: "PASS",
+				},
+			];
+
+			const result = generateVerifiableCredential["doesDocumentContainValidChip"](
+				documentType,
+				documentAuthenticityCheckBreakdown,
+			);
+
+			expect(result).toBe(false);
+		});
+
+		it("should return false if document type is valid but does not contain a valid chip", () => {
+			const documentType = "PASSPORT";
+			const documentAuthenticityCheckBreakdown = [
+				{
+					sub_check: "chip_csca_trusted",
+					result: "FAIL",
+				},
+			];
+
+			const result = generateVerifiableCredential["doesDocumentContainValidChip"](
+				documentType,
+				documentAuthenticityCheckBreakdown,
+			);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("calculateStrengthScore", () => {
+		it("should return the correct strength score for UKPASSPORT with valid chip", () => {
+			const documentType = "PASSPORT";
+			const documentContainsValidChip = true;
+
+			const result = generateVerifiableCredential["calculateStrengthScore"](
+				documentType,
+				"GBR",
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(4);
+		});
+
+		it("should return the correct strength score for RESIDENCE_PERMIT", () => {
+			const documentType = "RESIDENCE_PERMIT";
+			const documentContainsValidChip = false;
+
+			const result = generateVerifiableCredential["calculateStrengthScore"](
+				documentType,
+				"ALB",
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(4);
+		});
+
+		it("should return the correct strength score for DRIVING_LICENCE", () => {
+			const documentType = "DRIVING_LICENCE";
+			const documentContainsValidChip = false;
+
+			const result = generateVerifiableCredential["calculateStrengthScore"](
+				documentType,
+				"GBR",
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(3);
+		});
+
+		it("should return the correct strength score for EU identity card without valid chip", () => {
+			const documentType = "NATIONAL_ID";
+			const documentContainsValidChip = false;
+
+			const result = generateVerifiableCredential["calculateStrengthScore"](
+				documentType,
+				"ALB",
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(3);
+		});
+
+		it("should throw an error for an invalid document type", () => {
+			const documentType = "INVALID_DOCUMENT";
+			const documentContainsValidChip = true;
+
+			expect(() =>
+				generateVerifiableCredential["calculateStrengthScore"](documentType, "ALB", documentContainsValidChip),
+			).toThrow("Invalid documentType provided");
+		});
+	});
+
+	describe("calculateValidityScore", () => {
+		it("should return the correct validity score when authenticity recommendation is 'APPROVE' and document contains a valid chip", () => {
+			const authenticityRecommendation = "APPROVE";
+			const documentContainsValidChip = true;
+
+			const result = generateVerifiableCredential["calculateValidityScore"](
+				authenticityRecommendation,
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(3);
+		});
+
+		it("should return the correct validity score when authenticity recommendation is 'APPROVE' and document does not contain a valid chip", () => {
+			const authenticityRecommendation = "APPROVE";
+			const documentContainsValidChip = false;
+
+			const result = generateVerifiableCredential["calculateValidityScore"](
+				authenticityRecommendation,
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(2);
+		});
+
+		it("should return 0 validity score when authenticity recommendation is not 'APPROVE'", () => {
+			const authenticityRecommendation = "REJECT";
+			const documentContainsValidChip = true;
+
+			const result = generateVerifiableCredential["calculateValidityScore"](
+				authenticityRecommendation,
+				documentContainsValidChip,
+			);
+
+			expect(result).toBe(0);
+		});
+	});
+
+	describe("calculateVerificationProcessLevel", () => {
+		it("should return 3 for faceMatchCheck === 'APPROVE'", () => {
+			const faceMatchCheck = "APPROVE";
+
+			const result = generateVerifiableCredential["calculateVerificationProcessLevel"](faceMatchCheck);
+
+			expect(result).toBe(3);
+		});
+
+		it("should return 0 for faceMatchCheck !== 'APPROVE'", () => {
+			const faceMatchCheck = "REJECT";
+
+			const result = generateVerifiableCredential["calculateVerificationProcessLevel"](faceMatchCheck);
+
+			expect(result).toBe(0);
+		});
+	});
+
+	describe("getCounterIndicator", () => {
+		it("should return the correct counter indicators for face match rejection reason 'FACE_NOT_GENUINE'", () => {
+			const ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION = {
+				value: "APPROVE",
+			};
+			const ID_DOCUMENT_FACE_MATCH_RECOMMENDATION = {
+				value: "REJECT",
+				reason: "FACE_NOT_GENUINE",
+			};
+
+			const result = generateVerifiableCredential["getCounterIndicator"](
+				ID_DOCUMENT_FACE_MATCH_RECOMMENDATION,
+				ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION,
+				null,
+				null,
+				null,
+			);
+
+			expect(result).toEqual(["V01"]);
+		});
+
+		it("should return empty CI array if no rejection reasons match found", () => {
+			const ID_DOCUMENT_FACE_MATCH_RECOMMENDATION = {
+				value: "REJECT",
+				reason: "UNKNOWN_REASON",
+			};
+			const ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION = {
+				value: "APPROVE",
+			};
+
+			const result = generateVerifiableCredential["getCounterIndicator"](
+				ID_DOCUMENT_FACE_MATCH_RECOMMENDATION,
+				ID_DOCUMENT_AUTHENTICITY_RECOMMENDATION,
+				null,
+				null,
+				null,
+			);
+
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("attachPersonName", () => {
+		it("should attach the person name to the credential subject", () => {
+			const credentialSubject = {};
+			const givenName = "John";
+			const familyName = "Doe";
+
+			const result = generateVerifiableCredential["attachPersonName"](
+				credentialSubject,
+				givenName,
+				familyName,
+			);
+
+			expect(result).toEqual({
+				name: [
+					{
+						nameParts: [
+							{ type: "GivenName", value: "John" },
+							{ type: "FamilyName", value: "Doe" },
+						],
+					},
+				],
+			});
+		});
+	});
+
+	describe("attachDOB", () => {
+		it("should attach the date of birth to the credential subject", () => {
+			const credentialSubject = {};
+			const dateOfBirth = "1990-01-01";
+
+			const result = generateVerifiableCredential["attachDOB"](credentialSubject, dateOfBirth);
+
+			expect(result).toEqual({ birthDate: [{ value: "1990-01-01" }] });
+		});
+	});
+
+	describe("attachAddressInfo", () => {
+		it("should attach the address information to the credential subject", () => {
+			const credentialSubject = {};
+			const postalAddress = {
+				building_number: "123",
+				town_city: "City",
+				postal_code: "12345",
+				country: "Country",
+			};
+
+			const result = generateVerifiableCredential["attachAddressInfo"](credentialSubject, postalAddress);
+
+			expect(result).toEqual({
+				address: [
+					{
+						buildingNumber: "123",
+						addressLocality: "City",
+						postalCode: "12345",
+						addressCountry: "Country",
+					},
+				],
+			});
+		});
+	});
+
+	describe("attachEvidencePayload", () => {
+		it("should attach the evidence payload to the credential subject for UK driving license", () => {
+			const credentialSubject = {};
+			const documentType = "DRIVING_LICENCE";
+			const documentFields = {
+				document_number: "BOEJJ861281TP9DH",
+				expiration_date: "2025-01-01",
+				date_of_issue: "2020-01-01",
+				issuing_authority: "Authority",
+				formatted_address: "Address",
+			};
+
+			const result = generateVerifiableCredential["attachEvidencePayload"](
+				credentialSubject,
+				documentType,
+				documentFields,
+			);
+
+			expect(result).toEqual({
+				drivingPermit: [
+					{
+						personalNumber: "BOEJJ861281TP9DH",
+						expiryDate: "2025-01-01",
+						issueDate: "2020-01-01",
+						issueNumber: null,
+						issuedBy: "Authority",
+						fullAddress: "Address",
+					},
+				],
+			});
+		});
+
+		it("should attach the evidence payload to the credential subject for UK passport", () => {
+			const credentialSubject = {};
+			const documentType = "PASSPORT";
+			const documentFields = {
+				document_number: "123456789",
+				expiration_date: "2025-01-01",
+				issuing_country: "GBR",
+			};
+
+			const result = generateVerifiableCredential["attachEvidencePayload"](
+				credentialSubject,
+				documentType,
+				documentFields,
+			);
+
+			expect(result).toEqual({
+				passport: [
+					{
+						documentNumber: "123456789",
+						expiryDate: "2025-01-01",
+						icaoIssuerCode: "GBR",
+					},
+				],
+			});
+		});
+
+		it("should throw an error for an invalid document type", () => {
+			const credentialSubject = {};
+			const documentType = "INVALID_DOCUMENT";
+			const documentFields = {};
+
+			expect(() =>
+				generateVerifiableCredential["attachEvidencePayload"](
+					credentialSubject,
+					documentType,
+					documentFields,
+				),
+			).toThrow("Invalid documentType provided");
+		});
+	});
+
+	describe("getVerifiedCredentialInformation", () => {
+		const mockYotiSessionId = "yoti-session-id";
+		const mockCompletedYotiSessionPayload = {
+			resources: {
+				id_documents: [
+					{
+						document_type: "PASSPORT",
+					},
+				],
+			},
+			checks: [
+				{
+					type: "ID_DOCUMENT_AUTHENTICITY",
+					state: "DONE",
+					report: {
+						recommendation: {
+							value: "APPROVE",
+						},
+						breakdown: [],
+					},
+				},
+				{
+					type: "ID_DOCUMENT_FACE_MATCH",
+					state: "DONE",
+					report: {
+						recommendation: {
+							value: "APPROVE",
+						},
+						breakdown: [
+							{
+								sub_check: "manual_face_match",
+								result: "PASS",
+							},
+						],
+					},
+				},
+				{
+					type: "IBV_VISUAL_REVIEW_CHECK",
+					state: "DONE",
+					report: {
+						recommendation: {
+							value: "APPROVE",
+						},
+						breakdown: [],
+					},
+				},
+				{
+					type: "DOCUMENT_SCHEME_VALIDITY_CHECK",
+					state: "DONE",
+					report: {
+						recommendation: {
+							value: "APPROVE",
+						},
+						breakdown: [],
+					},
+				},
+				{
+					type: "PROFILE_DOCUMENT_MATCH",
+					state: "DONE",
+					report: {
+						recommendation: {
+							value: "APPROVE",
+						},
+						breakdown: [],
+					},
+				},
+			],
+		};
+		const mockDocumentFields = {
+			given_names: "John",
+			family_name: "Doe",
+			date_of_birth: "1990-01-01",
+		};
+
+		it("should return the verified credential information with all completed checks", () => {
+			const result = generateVerifiableCredential.getVerifiedCredentialInformation(
+				mockYotiSessionId,
+				mockCompletedYotiSessionPayload,
+				mockDocumentFields,
+			);
+
+			expect(result).toEqual({
+				"credentialSubject":{
+					 "birthDate":[
+						{
+								 "value":"1990-01-01",
+						},
+					 ],
+					 "name":[
+						{
+								 "nameParts":[
+								{
+											 "type":"GivenName",
+											 "value":"John",
+								},
+								{
+											 "type":"FamilyName",
+											 "value":"Doe",
+								},
+								 ],
+						},
+					 ],
+					 "passport":[
+						{
+								 "documentNumber":undefined,
+								 "expiryDate":undefined,
+								 "icaoIssuerCode":undefined,
+						},
+					 ],
+				},
+				"evidence":[
+					 {
+						"checkDetails":[
+								 {
+								"checkMethod":"vri",
+								"identityCheckPolicy":"published",
+								"txn":"yoti-session-id",
+								 },
+								 {
+								"biometricVerificationProcessLevel":3,
+								"checkMethod":"pvr",
+								"txn":"yoti-session-id",
+								 },
+						],
+						"strengthScore":3,
+						"type":"IdentityCheck",
+						"validityScore":2,
+						"verificationScore":3,
+					 },
+				],
+		 });
+		});
+
+		it("should throw an error when mandatory checks are missing", () => {
+			const incompletePayload = {
+				resources: {
+					id_documents: [
+						{
+							document_type: "PASSPORT",
+						},
+					],
+				},
+				checks: [
+					{
+						type: "ID_DOCUMENT_AUTHENTICITY",
+						state: "DONE",
+						report: {
+							recommendation: {
+								value: "APPROVE",
+							},
+							breakdown: [],
+						},
+					},
+					// Missing ID_DOCUMENT_FACE_MATCH check
+				],
+			};
+
+			expect(() =>
+				generateVerifiableCredential.getVerifiedCredentialInformation(
+					mockYotiSessionId,
+					incompletePayload,
+					mockDocumentFields,
+				),
+			).toThrow("Missing mandatory checks in Yoti completed payload");
+		});
+
+		it("should throw an error when mandatory checks are not all completed", () => {
+			const incompletePayload = {
+				resources: {
+					id_documents: [
+						{
+							document_type: "PASSPORT",
+						},
+					],
+				},
+				checks: [
+					{
+						type: "ID_DOCUMENT_AUTHENTICITY",
+						state: "DONE",
+						report: {
+							recommendation: {
+								value: "APPROVE",
+							},
+							breakdown: [],
+						},
+					},
+					{
+						type: "ID_DOCUMENT_FACE_MATCH",
+						state: "PENDING", // Not completed
+						report: {
+							recommendation: {
+								value: "APPROVE",
+							},
+							breakdown: [
+								{
+									sub_check: "manual_face_match",
+									result: "PASS",
+								},
+							],
+						},
+					},
+				],
+			};
+
+			expect(() =>
+				generateVerifiableCredential.getVerifiedCredentialInformation(
+					mockYotiSessionId,
+					incompletePayload,
+					mockDocumentFields,
+				),
+			).toThrow("Missing mandatory checks in Yoti completed payload");
+		});
+	});
+});

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -73,7 +73,7 @@ describe("VerifiableCredentialService", () => {
 		"iat":123456789,
 		"iss":"test-issuer",
 		"nbf":123456789,
-		"sub":"sub",
+		"sub":"urn:uuid:sub",
 		"vc":{
 		 "@context":[Constants.W3_BASE_CONTEXT, Constants.DI_CONTEXT],
 		 credentialSubject,

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -1,0 +1,180 @@
+/* eslint-disable @typescript-eslint/dot-notation */
+import { Logger } from "@aws-lambda-powertools/logger";
+import { VerifiableCredentialService } from "../../../services/VerifiableCredentialService";
+import { AppError } from "../../../utils/AppError";
+import { Constants } from "../../../utils/Constants";
+import { HttpCodesEnum } from "../../../utils/HttpCodesEnum";
+import { KmsJwtAdapter } from "../../../utils/KmsJwtAdapter";
+import { mock } from "jest-mock-extended";
+import { ISessionItem } from "../../../models/ISessionItem";
+import { AuthSessionState } from "../../../models/enums/AuthSessionState";
+
+jest.mock("../../../utils/KmsJwtAdapter");
+
+describe("VerifiableCredentialService", () => {
+	let verifiableCredentialService: VerifiableCredentialService;
+	const tableName = "test-table";
+	const issuer = "test-issuer";
+	const logger = mock<Logger>();
+	const kmsJwtAdapter = new KmsJwtAdapter("kid");
+
+	const credentialSubject = {
+		"birthDate":[
+			 {
+				"value":"1990-01-01",
+			 },
+		],
+		"name":[
+			 {
+				"nameParts":[
+						 {
+						"type":"GivenName",
+						"value":"John",
+						 },
+						 {
+						"type":"FamilyName",
+						"value":"Doe",
+						 },
+				],
+			 },
+		],
+		"passport":[
+			{
+				"documentNumber":"1234",
+				"expiryDate":"01-01-2010",
+				"icaoIssuerCode":"123456",
+			},
+		],
+			
+	 };
+
+	const evidence = [
+		{
+			 "checkDetails":[
+				{
+						 "checkMethod":"vri",
+						 "identityCheckPolicy":"published",
+						 "txn":"yoti-session-id",
+				},
+				{
+						 "biometricVerificationProcessLevel":3,
+						 "checkMethod":"pvr",
+						 "txn":"yoti-session-id",
+				},
+			 ],
+			 "strengthScore":3,
+			 "type":"IdentityCheck",
+			 "validityScore":2,
+			 "verificationScore":3,
+		},
+	];
+
+	const payloadToSign = {
+		"iat":123456789,
+		"iss":"test-issuer",
+		"nbf":123456789,
+		"sub":"sub",
+		"vc":{
+		 "@context":[Constants.W3_BASE_CONTEXT, Constants.DI_CONTEXT],
+		 credentialSubject,
+		 evidence,
+		 "type":[
+				Constants.VERIFIABLE_CREDENTIAL,
+				Constants.IDENTITY_CHECK_CREDENTIAL,
+			],
+		},
+	};
+
+	beforeEach(() => {
+		verifiableCredentialService = VerifiableCredentialService.getInstance(
+			tableName,
+			kmsJwtAdapter,
+			issuer,
+			logger,
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("generateSignedVerifiableCredentialJwt", () => {
+		const sessionItem: ISessionItem = {
+			sessionId: "sdfsdg",
+			clientId: "ipv-core-stub",
+			// pragma: allowlist nextline secret
+			accessToken: "AbCdEf123456",
+			// pragma: allowlist nextline secret
+			clientSessionId: "sdfssg",
+			authorizationCode: "",
+			authorizationCodeExpiryDate: 0,
+			redirectUri: "http://localhost:8085/callback",
+			accessTokenExpiryDate: 0,
+			expiryDate: 221848913376,
+			createdDate: 1675443004,
+			state: "Y@atr",
+			subject: "sub",
+			persistentSessionId: "sdgsdg",
+			clientIpAddress: "127.0.0.1",
+			attemptCount: 1,
+			authSessionState: AuthSessionState.F2F_YOTI_SESSION_CREATED,
+		};
+
+		it("should generate a signed verifiable credential JWT", async () => {
+			const getNow = jest.fn().mockReturnValue(123456789);
+
+			const signedJwt = "signed-jwt";
+			const signMock = jest.spyOn(kmsJwtAdapter, "sign").mockResolvedValue(signedJwt);
+
+			const result = await verifiableCredentialService.generateSignedVerifiableCredentialJwt(
+				sessionItem,
+				credentialSubject,
+				evidence,
+				getNow,
+			);
+
+			expect(getNow).toHaveBeenCalled();
+			expect(signMock).toHaveBeenCalledWith(payloadToSign);
+			expect(result).toBe(signedJwt);
+		});
+
+		it("should throw an AppError if signing the JWT fails", async () => {
+			const getNow = jest.fn().mockReturnValue(123456789);
+
+			const error = new Error("Failed to sign JWT");
+			const signMock = jest.spyOn(kmsJwtAdapter, "sign").mockRejectedValue(error);
+
+			await expect(
+				verifiableCredentialService.generateSignedVerifiableCredentialJwt(
+					sessionItem,
+					credentialSubject,
+					evidence,
+					getNow,
+				),
+			).rejects.toThrow(new AppError(HttpCodesEnum.SERVER_ERROR, "Failed to sign Jwt"));
+
+			expect(getNow).toHaveBeenCalled();
+			expect(signMock).toHaveBeenCalledWith(payloadToSign);
+		});
+	});
+
+	describe("buildVerifiableCredential", () => {
+		it("should build a verifiable credential with the provided subject and evidence", () => {
+			const verifiableCredential = verifiableCredentialService["buildVerifiableCredential"](
+				credentialSubject,
+				evidence,
+			);
+
+			expect(verifiableCredential["@context"]).toEqual([
+				Constants.W3_BASE_CONTEXT,
+				Constants.DI_CONTEXT,
+			]);
+			expect(verifiableCredential.type).toEqual([
+				Constants.VERIFIABLE_CREDENTIAL,
+				Constants.IDENTITY_CHECK_CREDENTIAL,
+			]);
+			expect(verifiableCredential.credentialSubject).toBe(credentialSubject);
+			expect(verifiableCredential.evidence).toBe(evidence);
+		});
+	});
+});

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -504,6 +504,7 @@ describe("YotiCallbackProcessor", () => {
 		expect(out.body).toBe("OK");
 	});
 
+
 	it("Throw sever error if completed Yoti session can not be found", async () => {
 		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(undefined);
 

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -492,7 +492,7 @@ describe("YotiCallbackProcessor", () => {
 								{
 											 "checkMethod":"pvr",
 											 "txn":"b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
-											 "biometricVerificationProcessLevel":3,
+											 "photoVerificationProcessLevel":3,
 								},
 								 ],
 						},

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -425,8 +425,8 @@ describe("YotiCallbackProcessor", () => {
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockF2fService.sendToTXMA).toHaveBeenCalledTimes(2);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
-		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(1, { "client_id": "ipv-core-stub", "component_id": "https://XXX-c.env.account.gov.uk", "event_name": "F2F_YOTI_END", "timestamp": absoluteTimeNow(), "user": { "govuk_signin_journey_id": "sdfssg", "ip_address": "127.0.0.1", "persistent_session_id": "sdgsdg", "session_id": "RandomF2FSessionID", "transaction_id": "", "user_id": "sub" } });
-		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(2, { "client_id": "ipv-core-stub", "component_id": "https://XXX-c.env.account.gov.uk", "event_name": "F2F_CRI_VC_ISSUED", "timestamp": absoluteTimeNow(), "user": { "govuk_signin_journey_id": "sdfssg", "ip_address": "127.0.0.1", "persistent_session_id": "sdgsdg", "session_id": "RandomF2FSessionID", "transaction_id": "", "user_id": "sub" } });
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(1, {"client_id": "ipv-core-stub", "component_id": "https://XXX-c.env.account.gov.uk", "event_name": "F2F_YOTI_END", "timestamp": absoluteTimeNow(), "user": {"govuk_signin_journey_id": "sdfssg", "ip_address": "127.0.0.1", "persistent_session_id": "sdgsdg", "session_id": "RandomF2FSessionID", "transaction_id": "", "user_id": "sub"}});
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(2, {"client_id": "ipv-core-stub", "component_id": "https://XXX-c.env.account.gov.uk", "event_name": "F2F_CRI_VC_ISSUED", "timestamp": absoluteTimeNow(), "user": {"govuk_signin_journey_id": "sdfssg", "ip_address": "127.0.0.1", "persistent_session_id": "sdgsdg", "session_id": "RandomF2FSessionID", "transaction_id": "", "user_id": "sub"}});
 
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledTimes(1);
@@ -435,7 +435,7 @@ describe("YotiCallbackProcessor", () => {
 			sub: "sub",
 			state: "Y@atr",
 			"https://vocab.account.gov.uk/v1/credentialJWT": JSON.stringify({
-				"sub":"sub",
+				"sub":"urn:uuid:sub",
 				"nbf":absoluteTimeNow(),
 				"iss":"https://XXX-c.env.account.gov.uk",
 				"iat":absoluteTimeNow(),

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -58,7 +58,7 @@ const createSessionPayload = {
 	user_tracking_id: "RandomF2FSessionID",
 	notifications: {
 		endpoint: "https://example.com/callback",
-		topics: ["SESSION_COMPLETION", "INSTRUCTIONS_EMAIL_REQUESTED"],
+		topics: ["SESSION_COMPLETION", "INSTRUCTIONS_EMAIL_REQUESTED", "THANK_YOU_EMAIL_REQUESTED"],
 		auth_token: "string",
 		auth_type: "BASIC",
 	},
@@ -101,6 +101,7 @@ const createSessionPayload = {
 			filter: {
 				type: "DOCUMENT_RESTRICTIONS",
 				inclusion: "INCLUDE",
+				allow_expired_documents: true,
 				documents: [
 					{
 						country_codes: ["GBR"],

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -5,7 +5,7 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { PersonIdentityItem } from "../../../models/PersonIdentityItem";
 import { AppError } from "../../../utils/AppError";
 import { HttpCodesEnum } from "../../../utils/HttpCodesEnum";
-import { CreateSessionPayload } from "../../../models/YotiPayloads";
+import { mock } from "jest-mock-extended";
 
 jest.mock("@aws-lambda-powertools/logger");
 jest.mock("axios");
@@ -49,7 +49,7 @@ const personDetails: PersonIdentityItem = {
 	],
 };
 
-const createSessionPayload: CreateSessionPayload = {
+const createSessionPayload = {
 	client_session_token_ttl: "950400",
 	resources_ttl: "1036800",
 	ibv_options: {
@@ -58,7 +58,7 @@ const createSessionPayload: CreateSessionPayload = {
 	user_tracking_id: "RandomF2FSessionID",
 	notifications: {
 		endpoint: "https://example.com/callback",
-		topics: ["SESSION_COMPLETION", "INSTRUCTIONS_EMAIL_REQUESTED", "THANK_YOU_EMAIL_REQUESTED"],
+		topics: ["SESSION_COMPLETION", "INSTRUCTIONS_EMAIL_REQUESTED"],
 		auth_token: "string",
 		auth_type: "BASIC",
 	},
@@ -104,7 +104,7 @@ const createSessionPayload: CreateSessionPayload = {
 				documents: [
 					{
 						country_codes: ["GBR"],
-						document_types: ["RESIDENCE_PERMIT"],
+						document_types: ["PASSPORT"],
 					},
 				],
 			},
@@ -164,16 +164,15 @@ const generateInstructionsPayload = {
 };
 
 describe("YotiService", () => {
-	let loggerMock: jest.Mocked<Logger>;
+	const logger = mock<Logger>();
 	let axiosMock: jest.Mocked<typeof axios>;
 	let yotiService: YotiService;
 
 	beforeEach(() => {
-		loggerMock = new Logger() as jest.Mocked<Logger>;
 		axiosMock = axios as jest.Mocked<typeof axios>;
 
 		yotiService = new YotiService(
-			loggerMock,
+			logger,
 			"CLIENT_SDK_ID",
 			"1036800",
 			"950400",
@@ -220,7 +219,7 @@ describe("YotiService", () => {
 	});
 
 	describe("createSession", () => {
-		const selectedDocument = "BRP";
+		const selectedDocument = "UKPASSPORT";
 		const YOTICALLBACKURL = "https://example.com/callback";
 
 		it("should create a Yoti session and return the session ID", async () => {
@@ -232,24 +231,6 @@ describe("YotiService", () => {
 			axiosMock.post.mockResolvedValue({ data: { session_id: "session123" } });
 
 			const sessionId = await yotiService.createSession(personDetails, selectedDocument, "GBR", YOTICALLBACKURL);
-
-			expect(generateYotiRequestMock).toHaveBeenCalled();
-			expect(axios.post).toHaveBeenCalledWith("https://example.com/api/sessions", createSessionPayload, {});
-			expect(sessionId).toBe("session123");
-		});
-
-		it("should set allow_expired_documents to true if PASSPORT selected", async () => {
-			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
-				url: "https://example.com/api/sessions",
-				config: {},
-			});
-			
-			createSessionPayload.required_documents[0].filter.documents[0].document_types[0] = "PASSPORT";
-			createSessionPayload.required_documents[0].filter.allow_expired_documents = true;
-
-			axiosMock.post.mockResolvedValue({ data: { session_id: "session123" } });
-
-			const sessionId = await yotiService.createSession(personDetails, "ukpassport", "GBR", YOTICALLBACKURL);
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.post).toHaveBeenCalledWith("https://example.com/api/sessions", createSessionPayload, {});
@@ -611,6 +592,50 @@ describe("YotiService", () => {
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.get).toHaveBeenCalledWith("https://example.com/api/sessions/session123", expect.any(Object));
+		});
+	});
+
+	describe("getMediaContent", () => {
+		const sessionId = "session123";
+		const mediaId = "media123";
+
+		it("should fetch Yoti media content and return the data", async () => {
+			const yotiRequest = {
+				url: "https://example.com/api/sessions/session123/media/media123/content",
+				config: {},
+			};
+			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue(yotiRequest);
+			const responseData = null;
+			axiosMock.get.mockResolvedValueOnce({ data: responseData });
+
+			const result = await yotiService.getMediaContent(sessionId, mediaId);
+
+			expect(generateYotiRequestMock).toHaveBeenCalled();
+			expect(axios.get).toHaveBeenCalledWith(
+				yotiRequest.url,
+				yotiRequest.config,
+			);
+			expect(result).toEqual(responseData);
+		});
+
+		it("should throw an AppError if there is an error fetching Yoti media content", async () => {
+			const yotiRequest = {
+				url: "https://example.com/api/sessions/session123/media/media123/content",
+				config: {},
+			};
+			jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue(yotiRequest);
+
+			const error = new Error("Failed to fetch media content");
+			axiosMock.get.mockRejectedValueOnce(error);
+
+			await expect(yotiService.getMediaContent(sessionId, mediaId)).rejects.toThrow(
+				new AppError(HttpCodesEnum.SERVER_ERROR, "Error fetching Yoti media content"),
+			);
+
+			expect(axios.get).toHaveBeenCalledWith(
+				yotiRequest.url,
+				yotiRequest.config,
+			);
 		});
 	});
 });

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -88,6 +88,7 @@ export type VerifiedCredentialEvidence = Array<{
 	validityScore: number;
 	verificationScore: number;
 	checkDetails?: Array<{
+		photoVerificationProcessLevel?: number;
 		checkMethod: string;
 		txn: string;
 		identityCheckPolicy?: string;
@@ -96,6 +97,7 @@ export type VerifiedCredentialEvidence = Array<{
 	}>;
 	ci?: [string];
 	failedCheckDetails?: Array<{
+		photoVerificationProcessLevel?: number;
 		checkMethod: string;
 		identityCheckPolicy?: string;
 		biometricVerificationProcessLevel?: number;
@@ -108,6 +110,8 @@ export interface VerifiedCredentialSubject {
 	address?: Address[];
 	drivingPermit?: DrivingPermit[];
 	passport?: Passport[];
+	residencePermit?: any[];
+	nationalId?: any[];
 }
 
 export interface Name {
@@ -141,10 +145,9 @@ export interface Address {
 export interface DrivingPermit {
 	personalNumber: string;
 	expiryDate: string;
-	issueNumber: any;
 	issuedBy: string;
 	issueDate: string;
-	fullAddress: string;
+	fullAddress?: string;
 }
 
 export interface Passport {

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -5,7 +5,8 @@ export interface CredentialSubject {
 export interface VerifiedCredential {
 	"@context": string[];
 	type: string[];
-	credentialSubject: CredentialSubject;
+	credentialSubject: VerifiedCredentialSubject;
+	evidence: VerifiedCredentialEvidence;
 }
 // limit to supported algs https://datatracker.ietf.org/doc/html/rfc7518
 export type Algorithm =
@@ -79,4 +80,75 @@ export class JsonWebTokenError extends Error {
 		super(message);
 		this.inner = error;
 	}
+}
+
+export type VerifiedCredentialEvidence = Array<{
+	type: string;
+	strengthScore: number;
+	validityScore: number;
+	verificationScore: number;
+	checkDetails?: Array<{
+		checkMethod: string;
+		txn: string;
+		identityCheckPolicy?: string;
+		activityFrom?: string;
+		biometricVerificationProcessLevel?: number;
+	}>;
+	ci?: [string];
+	failedCheckDetails?: Array<{
+		checkMethod: string;
+		identityCheckPolicy?: string;
+		biometricVerificationProcessLevel?: number;
+	}>;
+}>;
+
+export interface VerifiedCredentialSubject {
+	name?: Name[];
+	birthDate?: BirthDate[];
+	address?: Address[];
+	drivingPermit?: DrivingPermit[];
+	passport?: Passport[];
+}
+
+export interface Name {
+	nameParts: NamePart[];
+}
+
+export interface NamePart {
+	value: string;
+	type: string;
+}
+
+export interface BirthDate {
+	value: string;
+}
+
+export interface Address {
+	uprn?: string;
+	organisationName?: any;
+	subBuildingName?: any;
+	buildingNumber: string;
+	buildingName?: string;
+	dependentStreetName?: any;
+	streetName?: string;
+	doubleDependentAddressLocality?: any;
+	dependentAddressLocality?: any;
+	addressLocality: string;
+	postalCode: string;
+	addressCountry: string;
+}
+
+export interface DrivingPermit {
+	personalNumber: string;
+	expiryDate: string;
+	issueNumber: any;
+	issuedBy: string;
+	issueDate: string;
+	fullAddress: string;
+}
+
+export interface Passport {
+	documentNumber: string;
+	expiryDate: string;
+	icaoIssuerCode: string;
 }

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -95,7 +95,7 @@ export type VerifiedCredentialEvidence = Array<{
 		activityFrom?: string;
 		biometricVerificationProcessLevel?: number;
 	}>;
-	ci?: [string];
+	ci?: string[];
 	failedCheckDetails?: Array<{
 		photoVerificationProcessLevel?: number;
 		checkMethod: string;
@@ -143,15 +143,15 @@ export interface Address {
 }
 
 export interface DrivingPermit {
-	personalNumber: string;
-	expiryDate: string;
-	issuedBy: string;
-	issueDate: string;
+	personalNumber?: string;
+	expiryDate?: string;
+	issuedBy?: string;
+	issueDate?: string;
 	fullAddress?: string;
 }
 
 export interface Passport {
-	documentNumber: string;
-	expiryDate: string;
-	icaoIssuerCode: string;
+	documentNumber?: string;
+	expiryDate?: string;
+	icaoIssuerCode?: string;
 }

--- a/src/utils/PersonIdentityUtils.ts
+++ b/src/utils/PersonIdentityUtils.ts
@@ -7,7 +7,7 @@ export const personIdentityUtils = {
   	const familyNames: string[] = [];
 
   	for (const name of personDetails.name) {
-  		const nameParts = name.nameParts;
+  		const { nameParts } = name;
   		for (const namePart of nameParts) {
   			if (namePart.type === "GivenName") {
   				givenNames.push(namePart.value);

--- a/src/utils/YotiPayloadEnums.ts
+++ b/src/utils/YotiPayloadEnums.ts
@@ -9,6 +9,14 @@ export enum YotiDocumentTypesEnum {
 
 export const YOTI_DOCUMENT_COUNTRY_CODE = "GBR";
 
+export enum YotiSessionDocument {
+	APPROVE = "APPROVE",
+	REJECT = "REJECT",
+	DONE_STATE = "DONE",
+	SUBCHECK_PASS = "PASS",
+	CHIP_CSCA_TRUSTED = "chip_csca_trusted",
+}
+
 export const MANUAL_CHECK_TYPE = {
 	IBV: "IBV",
 	FALLBACK: "FALLBACK",
@@ -67,4 +75,3 @@ export const UK_POST_OFFICE = {
 	type: "UK_POST_OFFICE",
 	name: "UK Post Office Branch",
 };
-

--- a/src/utils/YotiPayloadEnums.ts
+++ b/src/utils/YotiPayloadEnums.ts
@@ -9,7 +9,10 @@ export enum YotiDocumentTypesEnum {
 
 export const YOTI_DOCUMENT_COUNTRY_CODE = "GBR";
 
+export const DOCUMENT_TYPES_WITH_CHIPS = ["PASSPORT", "NATIONAL_ID", "RESIDENCE_PERMIT"];
+
 export enum YotiSessionDocument {
+	COMPLETED = "COMPLETED",
 	APPROVE = "APPROVE",
 	REJECT = "REJECT",
 	DONE_STATE = "DONE",


### PR DESCRIPTION
## Proposed changes

### What changed

Parses the returned completed session from YOTI and generates a fully formed VC object containing the necessary evidence objects and scores to send back to IPV Core

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-502

**Example VC**

<img width="421" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/836ee65f-e143-48f3-8879-3995f3192215">
