### PR TITLE
F2F | BE | Update Dev stack to use YotiStub

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -71,10 +71,8 @@ Mappings:
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
-      YOTIBASEURL: "https://f2f-cri-outbound-proxy-proxy.review-o.dev.account.gov.uk/yoti"
-      #YOTIBASEURL: "https://f2f-yoti-stub-yotistub.review-o.dev.account.gov.uk"
-      YOTISDK: "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
-      #YOTISDK: "Mock1234"
+      YOTIBASEURL: "https://f2f-yoti-stub-yotistub.review-o.dev.account.gov.uk"
+      YOTISDK: "MockSDK"
       YOTICALLBACKURL: "https://some-domain.example"
       ISSUER: 'https://review-o.dev.account.gov.uk'
       DNSSUFFIX: review-o.dev.account.gov.uk


### PR DESCRIPTION
### What changed
Update Yoti URL for dev to point to the deployed Yoti Stub

### Why did it change
In dev we no longer want to be having direct integration to Yoti production 

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-675

<img width="1333" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/76e4cd11-7c43-462b-bcef-b56c9d315817">
<img width="1304" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/aa26ee92-0599-4b91-b343-68216dfaabf5">

<img width="1418" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/ca643fae-0fea-40a9-8c04-fc8a2c6c8680">

<img width="1401" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/9b949ea9-8ec0-41a6-9856-89449db4ce08">
