### PR TITLE
F2F-718 Add MethodSettings to REST APIGW definition

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -161,6 +161,9 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
+  IsPersonalIdentifiableInformationEnvironment: !Or
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -292,8 +295,18 @@ Resources:
           Parameters:
             Location: './f2f-spec.yaml'
         OpenApiVersion: 3.0.1
-
-
+      MethodSettings:
+        - LoggingLevel: INFO
+          MetricsEnabled: true
+          ThrottlingBurstLimit: 400
+          ThrottlingRateLimit: 200
+          # Disable data trace in production and integration to avoid logging customer sensitive information
+          DataTraceEnabled: !If
+            - IsPersonalIdentifiableInformationEnvironment
+            - false
+            - true
+          HttpMethod: "*"
+          ResourcePath: "/*"
       TracingEnabled: true
       Tags:
         Product: GOV.UK Sign In
@@ -312,7 +325,6 @@ Resources:
           !Ref Environment,
           logretentionindays,
         ]
-      # KmsKeyId: !GetAtt HelloWorldKmsKey.Arn
       Tags:
         - Key: Product
           Value: GOV.UK Sign In

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -1,4 +1,4 @@
-import { Template, Capture, Match } from "@aws-cdk/assertions";
+import { Template, Match } from "@aws-cdk/assertions";
 const { schema } = require("yaml-cfn");
 import { readFileSync } from "fs";
 import { load } from "js-yaml";
@@ -39,13 +39,23 @@ describe("Infra", () => {
 		});
 	});
 
-	it.skip("The template contains two API gateway resource", () => {
+	it("The template contains one API gateway resource", () => {
 		template.resourceCountIs("AWS::Serverless::Api", 1);
 	});
 
-	it.skip("Has tracing enabled on at least one API", () => {
-		template.hasResourceProperties("AWS::Serverless::Api", {
-			TracingEnabled: true,
+	it("Each API Gateway should have TracingEnabled", () => {
+		const apiGateways = template.findResources("AWS::Serverless::Api");
+		const apiGatewayList = Object.keys(apiGateways);
+		apiGatewayList.forEach((apiGatewayId) => {
+			expect(apiGateways[apiGatewayId].Properties.TracingEnabled).toEqual(true);
+		});
+	});
+
+	it("Each API Gateway should have MethodSettings defined", () => {
+		const apiGateways = template.findResources("AWS::Serverless::Api");
+		const apiGatewayList = Object.keys(apiGateways);
+		apiGatewayList.forEach((apiGatewayId) => {
+			expect(apiGateways[apiGatewayId].Properties.MethodSettings).toBeTruthy();
 		});
 	});
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added a MethodSettings block to the Serverless::Api definition

### Why did it change

Enables the APIGW execution logs; and ensures detailed data trace (request/response) logging is only enabled in environments not handling PII.

### Issue tracking

- [F2F-718](https://govukverify.atlassian.net/browse/F2F-718)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-718]: https://govukverify.atlassian.net/browse/F2F-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ