### PR TITLE
F2F-710: Amended Yoti Domain Name Resource

### DIFF
--- a/yoti-stub/template.yaml
+++ b/yoti-stub/template.yaml
@@ -265,12 +265,7 @@ Resources:
           - "${AWS::StackName}-${YOTISTUBURL}"
           - YOTISTUBURL:
               !FindInMap [ EnvironmentVariables, !Ref Environment, YOTISTUBURL ]
-        - !Sub
-          - "api.${YOTISTUBURL}"
-          - YOTISTUBURL:
-             !FindInMap [ EnvironmentVariables, !Ref Environment, YOTISTUBURL ]
-
-
+        - !FindInMap [ EnvironmentVariables, !Ref Environment, YOTISTUBURL ]
       DomainNameConfigurations:
         - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
           EndpointType: REGIONAL


### PR DESCRIPTION
### What changed

Removed the api url in the MockYotiApiGatewayCustomDomain resource which was added in error

### Why did it change

Was causing pipeline failures

### Issue tracking
- [F2F-710](https://govukverify.atlassian.net/browse/F2F-710)


[F2F-710]: https://govukverify.atlassian.net/browse/F2F-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ