### PR TITLE
[F2F-761] Adds manual_face_match to response for GET sessions/0103 in Yoti Mock

### DIFF
--- a/yoti-stub/src/data/getSessions/aiPass.ts
+++ b/yoti-stub/src/data/getSessions/aiPass.ts
@@ -222,10 +222,15 @@ export const AI_PASS = {
 											"details": [
 													{
 															"name": "confidence_score",
-															"value": "0.99"
+															"value": "0.20"
 													}
 											]
 									},
+									{
+										"sub_check": "manual_face_match",
+										"result": "PASS",
+										"details": []
+								}
 							]
 					},
 					"created": "2023-04-05T10:18:16Z",


### PR DESCRIPTION
## Proposed changes

### What changed

Updates the response for 0103 scenario (UK Passport Success - Chip NOT readable & Face Match NOT automated) by adding `manual_face_match `

<img width="836" alt="Screenshot 2023-06-12 at 10 58 48" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/117986969/59ef45d2-e2b9-4ff0-8c3d-e759923f9043">

### Why did it change

It wasn't there

### Issue tracking

- [F2F-761](https://govukverify.atlassian.net/browse/F2F-761)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[F2F-761]: https://govukverify.atlassian.net/browse/F2F-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ