### PR TITLE
[F2F-767] Modifying response to add JWT as a list instead of string

### DIFF
--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -19,9 +19,9 @@ import { YotiSessionDocument } from "../utils/YotiPayloadEnums";
 export class YotiCallbackProcessor {
 
   private static instance: YotiCallbackProcessor;
-	
+
   private readonly logger: Logger;
-	
+
   private readonly metrics: Metrics;
 
   private readonly yotiService: YotiService;
@@ -150,7 +150,7 @@ export class YotiCallbackProcessor {
   			await this.f2fService.sendToIPVCore({
   				sub: f2fSession.subject,
   				state: f2fSession.state,
-  				"https://vocab.account.gov.uk/v1/credentialJWT": signedJWT,
+  				"https://vocab.account.gov.uk/v1/credentialJWT": [signedJWT],
   			});
   		} catch (error) {
   			this.logger.error({ message: "Failed to send VC to IPV Core Queue" }, { error });

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -141,7 +141,7 @@ describe("F2f Service", () => {
     await expect(f2fService.sendToIPVCore({
       sub: "",
       state: "",
-      "https://vocab.account.gov.uk/v1/credentialJWT": "",
+      "https://vocab.account.gov.uk/v1/credentialJWT": [],
     })).rejects.toThrow(expect.objectContaining({
       statusCode: HttpCodesEnum.SERVER_ERROR,
     }));

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -398,7 +398,7 @@ describe("YotiCallbackProcessor", () => {
 		documentFields = getDocumentFields();
 		f2fSessionItem = getMockSessionItem();
 
-		
+
 	});
 
 	beforeEach(() => {
@@ -421,7 +421,7 @@ describe("YotiCallbackProcessor", () => {
 
 		const out: Response = await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
 
-		
+
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockF2fService.sendToTXMA).toHaveBeenCalledTimes(2);
 		// eslint-disable-next-line @typescript-eslint/unbound-method
@@ -434,7 +434,7 @@ describe("YotiCallbackProcessor", () => {
 		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledWith({
 			sub: "sub",
 			state: "Y@atr",
-			"https://vocab.account.gov.uk/v1/credentialJWT": JSON.stringify({
+			"https://vocab.account.gov.uk/v1/credentialJWT": [JSON.stringify({
 				"sub":"urn:uuid:sub",
 				"nbf":absoluteTimeNow(),
 				"iss":"https://XXX-c.env.account.gov.uk",
@@ -498,7 +498,7 @@ describe("YotiCallbackProcessor", () => {
 						},
 					 ],
 				},
-		 }),
+		 })],
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
@@ -536,7 +536,7 @@ describe("YotiCallbackProcessor", () => {
 
 		const out: Response = await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
 
-		
+
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockF2fService.sendToTXMA).toHaveBeenCalledTimes(2);
 

--- a/src/utils/IPVCoreEvent.ts
+++ b/src/utils/IPVCoreEvent.ts
@@ -1,13 +1,13 @@
 export interface IPVCoreEvent {
 	"sub": string;
 	"state": string;
-	"https://vocab.account.gov.uk/v1/credentialJWT": string;
+	"https://vocab.account.gov.uk/v1/credentialJWT": string[];
 }
 
 export const buildCoreEventFields = (sub: string, state: string, jwt: string): IPVCoreEvent => {
 	return {
 		sub,
 		state,
-		"https://vocab.account.gov.uk/v1/credentialJWT": jwt,
+		"https://vocab.account.gov.uk/v1/credentialJWT": [jwt],
 	};
 };


### PR DESCRIPTION
## Proposed changes

### What changed

Modifying response to contain JWT in a list instead of string as per ADR: https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0058-cri-ipv-async-result-comms.md

### Why did it change

IPC Core lambda unable to parse the SQS message

### Issue tracking

- [F2F-767](https://govukverify.atlassian.net/browse/F2F-767)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-767]: https://govukverify.atlassian.net/browse/F2F-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ