### PR TITLE
[F2F-859]: Returning PDF file for Yoti stub GET /sessions/{sessionId}/instructions/pdf

### DIFF
--- a/yoti-stub/src/services/YotiRequestProcessor.ts
+++ b/yoti-stub/src/services/YotiRequestProcessor.ts
@@ -1092,6 +1092,9 @@ export class YotiRequestProcessor {
 
         let pdfBytes;
         let successResp;
+        const lastUuidChars = sessionId.slice(-4);
+        const firstTwoChars = lastUuidChars.slice(0, 2);
+        this.logger.info({message: "last 4 ID chars", lastUuidChars});
         try {
             const pdfDoc = await PDFDocument.create();
             const page = pdfDoc.addPage();
@@ -1101,30 +1104,23 @@ export class YotiRequestProcessor {
             pdfBytes = await pdfDoc.saveAsBase64()
             successResp = {
                 headers: {
-                    'Content-Type': "application/pdf",
-                    "Access-Control-Allow-Origin": "*",
-                    'Accept': '*/*'
-                },
+                    'Content-Type': "application/octet-stream",
+                    "Access-Control-Allow-Origin":"*",
+                    'Accept': 'application/pdf'},
                 statusCode: 200,
                 body: pdfBytes,
                 isBase64Encoded: true
             }
 
+            if (SUPPORTED_DOCUMENTS.includes(firstTwoChars)) {
+                this.logger.info("fetchInstructionsPdf",JSON.stringify(successResp));
+                return successResp;
+            }
 
         } catch (err) {
             console.log("Got err " + err)
             throw err;
         }
-
-        const lastUuidChars = sessionId.slice(-4);
-        const firstTwoChars = lastUuidChars.slice(0, 2);
-        this.logger.info({message: "last 4 ID chars", lastUuidChars});
-
-        if (SUPPORTED_DOCUMENTS.includes(firstTwoChars)) {
-            this.logger.info("fetchInstructionsPdf", JSON.stringify(GET_INSTRUCTIONS_PDF_400));
-            return new Response(HttpCodesEnum.OK, JSON.stringify(GET_INSTRUCTIONS_PDF_400));
-        }
-
 
         switch (lastUuidChars) {
             case '4400':


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Modified response for  GET /sessions/{sessionId}/instructions/pdf in Yoti stub to return a PDF file for positive scenario

### Why did it change

To fix defect as was returning a text file with payload errors

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-859](https://govukverify.atlassian.net/browse/F2F-859)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

**Testing**

https://github.com/alphagov/di-ipv-cri-f2f-api/assets/26764987/333231ba-3868-46e1-9b43-48754fc17999



### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-859]: https://govukverify.atlassian.net/browse/F2F-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ