### PR TITLE
[F2F-490] Adding unit-tests to test govNotify retry logic

### DIFF
--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -13,3 +13,4 @@ process.env.YOTI_KEY_SSM_PATH = "/dev/YOTI/PRIVATEKEY"
 process.env.GOVUKNOTIFY_API_KEY_SSM_PATH = "/dev/f2f-gov-notify/lsdkgl"
 process.env.PERSON_IDENTITY_TABLE_NAME = "PERSONIDENTITYTABLE"
 process.env.YOTICALLBACKURL = "www.test.com/callback";
+process.env.GOVUKNOTIFY_BACKOFF_PERIOD_MS = "10";

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -83,7 +83,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService fails and doesnt retry when GovNotify throws an error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [
@@ -104,7 +104,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService retries when GovNotify throws a 500 error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [
@@ -126,7 +126,7 @@ describe("SendEmailProcessor", () => {
 	});
 
 	it("SendEmailService retries when GovNotify throws a 429 error", async () => {
-		mockGovNotify.sendEmail = jest.fn().mockRejectedValue( {
+		mockGovNotify.sendEmail.mockRejectedValue( {
 			"response": {
 				"data": {
 					"errors": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed
Added unit-tests to test GovNotify's retry logic when 500/429 errors are received.

### Why did it change

To be able to verify that the re-try logic in GovNotify works as expected.

