### PR TITLE
Gov notify F2F templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # di-ipv-cri-f2f-api
+
+# Gov Notify Templates
+The gov-notify-templates directory contains the templates required for sending email notification to the user. The name of the file matches the name of the template in the Gov notify portal for Face to Face Production service. The content of the file has the subject line and the message which should be copied without any changes as it includes gov notify formatting markdown.

--- a/gov-notify-templates/ConfirmationEmail
+++ b/gov-notify-templates/ConfirmationEmail
@@ -1,0 +1,36 @@
+Subject:
+
+Go to the Post Office within 10 days to finish proving your identity
+
+Message:
+
+Dear ((first name)) ((last name)),
+
+To finish proving your identity, you need to go to your chosen Post Office within the next 10 days.
+
+#What you need to take to the Post Office
+When you go to the Post Office, make sure to take your:
+
+*chosen photo ID
+*Post Office customer letter
+
+You can download your Post Office customer letter at: ((link_to_file))
+
+#At the Post Office
+You can show your Post Office customer letter on your phone or tablet, or take a printed copy with you.
+
+A member of Post Office staff will scan your photo ID and take a photo of you.
+
+You’ll find details of your chosen Post Office in your customer letter. But you can go to any Post Office that offers in-branch verification: https://www.postoffice.co.uk/identity/in-branch-verification-service#bf-full-width
+
+If you do not go to a Post Office within the next 10 days, you’ll need to start proving your identity again.
+
+#After you’ve been to the Post Office
+You’ll get an email about the result of your identity check – usually within a day of visiting the Post Office.
+
+#If you need help
+Contact the GOV.​UK One Login support team: https://signin.account.gov.uk/contact-us
+
+Regards,
+
+GOV.​UK One Login team


### PR DESCRIPTION
## Proposed changes
Added a file with F2F gov notify email template with formatting.

### Why did it change

We need a permanent location to store Gov notify  template backups.

### Issue tracking
- [F2F-386](https://govukverify.atlassian.net/browse/F2F-386)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-359]: https://govukverify.atlassian.net/browse/F2F-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[F2F-386]: https://govukverify.atlassian.net/browse/F2F-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ