### PR TITLE
F2F-838: Production Testing | Disable permissions to SQS receive functions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -997,9 +997,10 @@ Resources:
               - "sqs:ReceiveMessage"
             Resource:
               - !GetAtt TxMASQSQueue.Arn
-            Principal:
-              AWS:
-                - !FindInMap [TxMAAccounts, !Ref Environment, EVENTS]
+            # F2F-838 - Temporarily removed for Production Testing | Remove permissions for VCs and TxMA Event propagation downstream
+            # Principal:
+            #   AWS:
+            #     - !FindInMap [TxMAAccounts, !Ref Environment, EVENTS]
 
   TxMASQSQueueDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -1809,9 +1810,10 @@ Resources:
               - "sqs:ReceiveMessage"
             Resource:
               - !GetAtt IPVCoreSQSQueue.Arn
-            Principal:
-              AWS:
-                - !FindInMap [EnvironmentVariables, !Ref Environment, IPVCOREACCOUNT]
+            # F2F-838 - Temporarily removed for Production Testing | Remove permissions for VCs and TxMA Event propagation downstream
+            # Principal:
+            #   AWS:
+            #     - !FindInMap [EnvironmentVariables, !Ref Environment, IPVCOREACCOUNT]
 
   IPVCoreDeadLetterQueue:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
- Disabled the TxMA and IPV core services SQS message subscriptions.
- This is done temporarily for Production testing. 

- [F2F-838](https://govukverify.atlassian.net/browse/F2F-838)


[F2F-838]: https://govukverify.atlassian.net/browse/F2F-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ