### PR TITLE
F2F-910 Enhance logging in Yoti Mock

### DIFF
--- a/yoti-stub/src/MockYotiSessionHandler.ts
+++ b/yoti-stub/src/MockYotiSessionHandler.ts
@@ -105,16 +105,16 @@ class MockYotiSessionHandler implements LambdaInterface {
 			 case ResourcesEnum.INSTRUCTIONS:
 				 if (event.httpMethod === "PUT") {
 					 try {
-						 logger.info("Event received: PutInstructions", {event});
+					 	logger.info("Event received: PutInstructions", {event});
 
-						 let payload = event.body;
-							let payloadParsed;
+					 	let payload = event.body;
+						let payloadParsed;
 
-						if(payload){
+						if(payload) {
 							if(event.isBase64Encoded){
 								payloadParsed=  JSON.parse(Buffer.from(payload, 'base64').toString('binary'));
 							}
-							else{
+							else {
 								payloadParsed = JSON.parse(payload);
 							}
 						}

--- a/yoti-stub/src/MockYotiSessionHandler.ts
+++ b/yoti-stub/src/MockYotiSessionHandler.ts
@@ -107,6 +107,20 @@ class MockYotiSessionHandler implements LambdaInterface {
 					 try {
 						 logger.info("Event received: PutInstructions", {event});
 
+						 let payload = event.body;
+							let payloadParsed;
+
+						if(payload){
+							if(event.isBase64Encoded){
+								payloadParsed=  JSON.parse(Buffer.from(payload, 'base64').toString('binary'));
+							}
+							else{
+								payloadParsed = JSON.parse(payload);
+							}
+						}
+
+						logger.info("PutInstructions payload", {payloadParsed});
+
 						 if (event && event.pathParameters) {
 							 // Extract attributes from queryStringParameters and add them to the data object
 							 const sessionId = event.pathParameters?.sessionId;

--- a/yoti-stub/src/services/YotiRequestProcessor.ts
+++ b/yoti-stub/src/services/YotiRequestProcessor.ts
@@ -98,7 +98,7 @@ export class YotiRequestProcessor {
      */
     async createSession(event: APIGatewayProxyEvent, incomingPayload: any): Promise<Response> {
         this.logger.info("START OF CREATESESSION")
-
+				this.logger.info("/createSession Payload", {incomingPayload});
         const fullName = incomingPayload.resources.applicant_profile.full_name;
         const yotiSessionItem = new YotiSessionItem();
         const yotiSessionId = randomUUID();

--- a/yoti-stub/src/services/YotiRequestProcessor.ts
+++ b/yoti-stub/src/services/YotiRequestProcessor.ts
@@ -98,7 +98,7 @@ export class YotiRequestProcessor {
      */
     async createSession(event: APIGatewayProxyEvent, incomingPayload: any): Promise<Response> {
         this.logger.info("START OF CREATESESSION")
-				this.logger.info("/createSession Payload", {incomingPayload});
+	this.logger.info("/createSession Payload", {incomingPayload});
         const fullName = incomingPayload.resources.applicant_profile.full_name;
         const yotiSessionItem = new YotiSessionItem();
         const yotiSessionId = randomUUID();


### PR DESCRIPTION
### What changed

Logs out the /createSession payload in Yoti Mock to verify changes in documentSelection are as expected

https://govukverify.atlassian.net/browse/F2F-910

**/createSession**
<img width="353" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/859aa8f9-4b38-48ad-8653-0aa8737873c2">

**PUT Instructions**
<img width="635" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/e3f4d71b-e320-4f44-ba5a-72aa0042c966">

