### PR TITLE
F2F-908 Resolving misalignment with Address and name fields in request to Yoti

### DIFF
--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -225,11 +225,12 @@ export class YotiService {
 	):Promise<number | undefined> {
 		const nameParts = personIdentityUtils.getNames(personDetails);
 		const givenNames = nameParts.givenNames.length > 1 ? nameParts.givenNames.join(' ') : nameParts.givenNames[0];
+		const familyNames = nameParts.familyNames.length > 1 ? nameParts.familyNames.join(' ') : nameParts.familyNames[0];
 
 		const payloadJSON = {
 			contact_profile: {
 				first_name: givenNames,
-  			last_name: `${nameParts.familyNames[0]}`,
+  			last_name: familyNames,
   			email: personIdentityUtils.getEmailAddress(personDetails),
 			},
 			documents: requirements,

--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -61,9 +61,10 @@ export class YotiService {
 	): ApplicantProfile {
 		const nameParts = personIdentityUtils.getNames(personDetails);
 		const givenNames = nameParts.givenNames.length > 1 ? nameParts.givenNames.join(' ') : nameParts.givenNames[0];
+		const familyNames = nameParts.familyNames.length > 1 ? nameParts.familyNames.join(' ') : nameParts.familyNames[0];
 
 		return {
-			full_name: `${givenNames} ${nameParts.familyNames[0]}`,
+			full_name: `${givenNames} ${familyNames}`,
 			date_of_birth: `${personDetails.birthDate.map((bd) => ({ value: bd.value }))[0].value}`,
 			structured_postal_address: personIdentityUtils.getYotiStructuredPostalAddress(personDetails),
 		};
@@ -227,7 +228,7 @@ export class YotiService {
 
 		const payloadJSON = {
 			contact_profile: {
-				first_name: `${givenNames}`,
+				first_name: givenNames,
   			last_name: `${nameParts.familyNames[0]}`,
   			email: personIdentityUtils.getEmailAddress(personDetails),
 			},

--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -60,9 +60,10 @@ export class YotiService {
 		personDetails: PersonIdentityItem,
 	): ApplicantProfile {
 		const nameParts = personIdentityUtils.getNames(personDetails);
+		const givenNames = nameParts.givenNames.length > 1 ? nameParts.givenNames.join(' ') : nameParts.givenNames[0];
 
 		return {
-			full_name: `${nameParts.givenNames[0]} ${nameParts.familyNames[0]}`,
+			full_name: `${givenNames} ${nameParts.familyNames[0]}`,
 			date_of_birth: `${personDetails.birthDate.map((bd) => ({ value: bd.value }))[0].value}`,
 			structured_postal_address: personIdentityUtils.getYotiStructuredPostalAddress(personDetails),
 		};
@@ -222,10 +223,11 @@ export class YotiService {
 		PostOfficeSelection: PostOfficeInfo,
 	):Promise<number | undefined> {
 		const nameParts = personIdentityUtils.getNames(personDetails);
+		const givenNames = nameParts.givenNames.length > 1 ? nameParts.givenNames.join(' ') : nameParts.givenNames[0];
 
 		const payloadJSON = {
 			contact_profile: {
-				first_name: `${nameParts.givenNames[0]}`,
+				first_name: `${givenNames}`,
   			last_name: `${nameParts.familyNames[0]}`,
   			email: personIdentityUtils.getEmailAddress(personDetails),
 			},

--- a/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
+++ b/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
@@ -125,7 +125,7 @@ function getYotiSessionInfo(): YotiSessionInfo {
 						{
 							"type":"DOCUMENT_SCHEME_VALIDITY_CHECK",
 							"state":"REQUIRED",
-							"scheme":"UK_DBS",
+							"scheme":"UK_GDS",
 						},
 						{
 							"type":"PROFILE_DOCUMENT_MATCH",

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -328,7 +328,7 @@ function getCompletedYotiSession(): YotiCompletedSession {
 				},
 				"created": "2023-04-05T10:18:16Z",
 				"last_updated": "2023-04-05T10:18:16Z",
-				"scheme": "UK_DBS",
+				"scheme": "UK_GDS",
 			},
 			{
 				"type": "PROFILE_DOCUMENT_MATCH",

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -81,7 +81,7 @@ const createSessionPayload = {
 			type: "DOCUMENT_SCHEME_VALIDITY_CHECK",
 			config: {
 				manual_check: "IBV",
-				scheme: "UK_DBS",
+				scheme: "UK_GDS",
 			},
 		},
 		{
@@ -123,12 +123,12 @@ const createSessionPayload = {
 	],
 	resources: {
 		applicant_profile: {
-			full_name: "Frederick Flintstone",
+			full_name: "Frederick Joseph Flintstone",
 			date_of_birth: "1960-02-02",
 			structured_postal_address: {
 				address_format: 1,
 				building_number: "32",
-				address_line1: "Sherman Wallaby Way",
+				address_line1: "32 Sherman Wallaby Way",
 				town_city: "Sidney",
 				postal_code: "F1 1SH",
 				country_iso: "GBR",
@@ -140,7 +140,7 @@ const createSessionPayload = {
 
 const generateInstructionsPayload = {
 	contact_profile: {
-		first_name: "Frederick",
+		first_name: "Frederick Joseph",
 		last_name: "Flintstone",
 		email: "test123@gov.uk",
 	},
@@ -207,7 +207,7 @@ describe("YotiService", () => {
 			const applicantProfile = yotiService["getApplicantProfile"](personDetails);
 			const expectedPostalAddress = {
 				address_format: 1,
-				address_line1: "Sherman Wallaby Way",
+				address_line1: "32 Sherman Wallaby Way",
 				building_number: "32",
 				country: "United Kingdom",
 				country_iso: "GBR",
@@ -215,7 +215,7 @@ describe("YotiService", () => {
 				town_city: "Sidney",
 			};
 
-			expect(applicantProfile.full_name).toBe("Frederick Flintstone");
+			expect(applicantProfile.full_name).toBe("Frederick Joseph Flintstone");
 			expect(applicantProfile.date_of_birth).toBe("1960-02-02");
 			expect(applicantProfile.structured_postal_address).toEqual(expectedPostalAddress);
 		});
@@ -301,7 +301,7 @@ describe("YotiService", () => {
 									state: "REQUIRED",
 								},
 								{
-									scheme: "UK_DBS",
+									scheme: "UK_GDS",
 									state: "REQUIRED",
 									type: "DOCUMENT_SCHEME_VALIDITY_CHECK",
 								},
@@ -367,7 +367,7 @@ describe("YotiService", () => {
 									type: "IBV_VISUAL_REVIEW_CHECK",
 								},
 								{
-									scheme: "UK_DBS",
+									scheme: "UK_GDS",
 									state: "REQUIRED",
 									type: "DOCUMENT_SCHEME_VALIDITY_CHECK",
 								},

--- a/src/utils/PersonIdentityUtils.ts
+++ b/src/utils/PersonIdentityUtils.ts
@@ -1,4 +1,5 @@
 import { PersonIdentityItem } from "../models/PersonIdentityItem";
+import { YOTI_DOCUMENT_COUNTRY_CODE, YOTI_ADDRESS_FORMAT_CODE } from "./YotiPayloadEnums";
 
 export const personIdentityUtils = {
 
@@ -29,12 +30,12 @@ export const personIdentityUtils = {
 		const address = personDetails.addresses[0];
 
 		return {
-  		address_format: 1,
+  		address_format: YOTI_ADDRESS_FORMAT_CODE,
   		building_number: address.buildingNumber,
   		address_line1: `${address.buildingNumber} ${address.buildingName ? `${address.buildingName} ` : ''}${address.streetName}`.trim(),
   		town_city: address.addressLocality,
   		postal_code: address.postalCode,
-  		country_iso: "GBR",
+  		country_iso: YOTI_DOCUMENT_COUNTRY_CODE,
   		country: address.addressCountry,
   	};
 	},

--- a/src/utils/PersonIdentityUtils.ts
+++ b/src/utils/PersonIdentityUtils.ts
@@ -31,7 +31,7 @@ export const personIdentityUtils = {
 		return {
   		address_format: 1,
   		building_number: address.buildingNumber,
-  		address_line1: `${address.buildingName} ${address.streetName}`,
+  		address_line1: `${address.buildingNumber} ${address.buildingName ? `${address.buildingName} ` : ''}${address.streetName}`.trim(),
   		town_city: address.addressLocality,
   		postal_code: address.postalCode,
   		country_iso: "GBR",

--- a/src/utils/YotiPayloadEnums.ts
+++ b/src/utils/YotiPayloadEnums.ts
@@ -9,6 +9,10 @@ export enum YotiDocumentTypesEnum {
 
 export const YOTI_DOCUMENT_COUNTRY_CODE = "GBR";
 
+export const YOTI_ADDRESS_FORMAT_CODE = 1;
+
+export const YOTI_SCHEME_CHECK = "UK_GDS"
+
 export const DOCUMENT_TYPES_WITH_CHIPS = ["PASSPORT", "NATIONAL_ID", "RESIDENCE_PERMIT"];
 
 export enum YotiSessionDocument {
@@ -44,7 +48,7 @@ export const YOTI_CHECKS = {
 		"type": "DOCUMENT_SCHEME_VALIDITY_CHECK",
 		"config": {
 			"manual_check": MANUAL_CHECK_TYPE.IBV,
-			"scheme": "UK_GDS",
+			"scheme": YOTI_SCHEME_CHECK,
 		},
 	},
 	ID_DOCUMENT_AUTHENTICITY : {

--- a/src/utils/YotiPayloadEnums.ts
+++ b/src/utils/YotiPayloadEnums.ts
@@ -44,7 +44,7 @@ export const YOTI_CHECKS = {
 		"type": "DOCUMENT_SCHEME_VALIDITY_CHECK",
 		"config": {
 			"manual_check": MANUAL_CHECK_TYPE.IBV,
-			"scheme": "UK_DBS",
+			"scheme": "UK_GDS",
 		},
 	},
 	ID_DOCUMENT_AUTHENTICITY : {

--- a/yoti-stub/src/data/createSession.ts
+++ b/yoti-stub/src/data/createSession.ts
@@ -28,7 +28,7 @@ export const CREATE_SESSION = {
           "type": "DOCUMENT_SCHEME_VALIDITY_CHECK",
           "config": {
               "manual_check": "IBV",
-              "scheme": "UK_DBS"
+              "scheme": "UK_GDS"
           }
       },
       {

--- a/yoti-stub/src/data/getSessions/aiPass.ts
+++ b/yoti-stub/src/data/getSessions/aiPass.ts
@@ -269,7 +269,7 @@ export const AI_PASS = {
 					},
 					"created": "2023-04-05T10:18:16Z",
 					"last_updated": "2023-04-05T10:18:16Z",
-					"scheme": "UK_DBS"
+					"scheme": "UK_GDS"
 			},
 			{
 					"type": "PROFILE_DOCUMENT_MATCH",

--- a/yoti-stub/src/data/getSessions/responses.ts
+++ b/yoti-stub/src/data/getSessions/responses.ts
@@ -274,7 +274,7 @@ export const VALID_RESPONSE = {
           },
           "created": "2023-04-05T10:18:16Z",
           "last_updated": "2023-04-05T10:18:16Z",
-          "scheme": "UK_DBS"
+          "scheme": "UK_GDS"
       },
       {
           "type": "PROFILE_DOCUMENT_MATCH",

--- a/yoti-stub/src/models/YotiSessionRequest.ts
+++ b/yoti-stub/src/models/YotiSessionRequest.ts
@@ -40,7 +40,7 @@ export class YotiSessionRequest {
                        {
                            "type": "DOCUMENT_SCHEME_VALIDITY_CHECK",
                            "state": "REQUIRED",
-                           "scheme": "UK_DBS"
+                           "scheme": "UK_GDS"
                        },
                        {
                            "type": "PROFILE_DOCUMENT_MATCH",

--- a/yoti-stub/yoti-spec.yaml
+++ b/yoti-stub/yoti-spec.yaml
@@ -393,7 +393,7 @@ components:
           enum: [ DOCUMENT_SCHEME_VALIDITY_CHECK ]
         scheme:
           type: string
-          example: "UK_DBS"
+          example: "UK_GDS"
         state:
           type: string
           enum: [ CREATED, READY, PENDING, DONE, INTERNAL_ERROR ]
@@ -1572,7 +1572,7 @@ components:
       #            propertyName: type
       #            mapping:
       #              PROOF_OF_ADDRESS: "#/components/schemas/ProveAddressObjective"
-      #              UK_DBS: "#/components/schemas/UkDbsObjective"
+      #              UK_GDS: "#/components/schemas/UkDbsObjective"
       required:
         - type
         - objective
@@ -1591,7 +1591,7 @@ components:
       properties:
         type:
           type: string
-          enum: [UK_DBS]
+          enum: [UK_GDS]
         config:
           type: object
       required:


### PR DESCRIPTION
### What changed

- Adds any middle names the user supplies in FE when making call to create Session and PUT Instructions (Generate PDF) in Yoti
- Change the scheme from UK_DBS to UK_GDS to allow for postmaster to accept passports expired within the past 18 months
- Adds building number to address_line1 for applicant profile
- null checks on buldingName so empty strings aren't added in address_line1

<img width="429" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/e7f41710-350f-4703-9fdd-d8a7d52b1b82">

<img width="592" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/6b2ec3fc-e2ca-44cd-aa4b-8d4d8c37d635">



https://govukverify.atlassian.net/browse/F2F-908
