### PR TITLE
[F2F-909] Adding backward compatible PO Name to /documentSelection

### DIFF
--- a/src/models/YotiPayloads.ts
+++ b/src/models/YotiPayloads.ts
@@ -15,6 +15,7 @@ export interface ApplicantProfile {
 }
 
 export interface PostOfficeInfo {
+	name?: string;
 	address: string;
 	post_code: string;
 	location: {

--- a/src/services/YotiService.ts
+++ b/src/services/YotiService.ts
@@ -236,7 +236,7 @@ export class YotiService {
 			documents: requirements,
 			branch: {
 				type: UK_POST_OFFICE.type,
-				name: UK_POST_OFFICE.name,
+				name: PostOfficeSelection.name ? PostOfficeSelection.name : UK_POST_OFFICE.name,
 				address: PostOfficeSelection.address,
 				post_code: PostOfficeSelection.post_code,
 				location: {

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -481,7 +481,7 @@ describe("YotiService", () => {
 		}
 
 
-		it("should generate instructions and return OK status code", async () => {
+		it("should generate instructions using hardcoded PO name and return OK status code", async () => {
 			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
 				url: "https://example.com/api/sessions/session123/instructions",
 				config: {},
@@ -500,7 +500,7 @@ describe("YotiService", () => {
 			expect(statusCode).toBe(HttpCodesEnum.OK);
 		});
 
-		it("should include post office name in Yoti call if included in request", async () => {
+		it("should include the received PO name from FE in the Yoti putInstructions call", async () => {
 			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
 				url: "https://example.com/api/sessions/session123/instructions",
 				config: {},

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -475,6 +475,12 @@ describe("YotiService", () => {
 			post_code: "SW19 4NS",
 		};
 
+		const PostOfficeSelectionWithName = {
+			...PostOfficeSelection,
+			name: "The Funkytown Post office",
+		}
+
+
 		it("should generate instructions and return OK status code", async () => {
 			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
 				url: "https://example.com/api/sessions/session123/instructions",
@@ -489,6 +495,33 @@ describe("YotiService", () => {
 			expect(axios.put).toHaveBeenCalledWith(
 				"https://example.com/api/sessions/session123/instructions",
 				generateInstructionsPayload,
+				{},
+			);
+			expect(statusCode).toBe(HttpCodesEnum.OK);
+		});
+
+		it("should include post office name if include in request", async () => {
+			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
+				url: "https://example.com/api/sessions/session123/instructions",
+				config: {},
+			});
+
+			axiosMock.put.mockResolvedValueOnce({});
+
+			const statusCode = await yotiService.generateInstructions(sessionID, personDetails, requirements, PostOfficeSelectionWithName);
+
+			const generateInstructionsPayloadWithName = {
+				...generateInstructionsPayload,
+				branch: {
+					...generateInstructionsPayload.branch,
+					name: "The Funkytown Post office",
+				},
+			}
+	
+			expect(generateYotiRequestMock).toHaveBeenCalled();
+			expect(axios.put).toHaveBeenCalledWith(
+				"https://example.com/api/sessions/session123/instructions",
+				generateInstructionsPayloadWithName,
 				{},
 			);
 			expect(statusCode).toBe(HttpCodesEnum.OK);

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -500,7 +500,7 @@ describe("YotiService", () => {
 			expect(statusCode).toBe(HttpCodesEnum.OK);
 		});
 
-		it("should include post office name if include in request", async () => {
+		it("should include post office name in Yoti call if included in request", async () => {
 			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
 				url: "https://example.com/api/sessions/session123/instructions",
 				config: {},


### PR DESCRIPTION
## Proposed changes

### What changed

As part of https://github.com/alphagov/di-ipv-cri-f2f-api/pull/150 we reverted changes to accept PO name from FE. Adding this change back in but making it conditional so the BE is not dependant on the FE sending this value.
If present the PO name will be sent to YOTI else a Hardcoded value will be sent

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-909

**Without Name**
<img width="704" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/3ae8a301-59c4-4782-9b76-71b6513fbc05">

<img width="597" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/7e891d08-f617-4164-b5f2-96a01c1e0d7c">

**WIth Name**
<img width="615" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/9415a895-423d-4752-b625-92c45c8f04db">

<img width="667" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/51ac9b51-3231-466c-a1ad-5c1073e3791f">



