### PR TITLE
reverting validation message change on expired auth header

### DIFF
--- a/src/tests/api/DocumentSelectionNegativePath.test.ts
+++ b/src/tests/api/DocumentSelectionNegativePath.test.ts
@@ -71,7 +71,7 @@ describe("Negative Path /userInfo Endpoint", () => {
 		// Post User Info
 		const userInfoResponse = await userInfoPost("Bearer " + constants.DEV_F2F_EXPIRED_ACCESS_TOKEN);
 		expect(userInfoResponse.status).toBe(400);
-		expect(userInfoResponse.data).toBe("Failed to Validate - Authentication header: Failed to verify signature"); 
+		expect(userInfoResponse.data).toBe("Failed to Validate - Authentication header: Verification of exp failed"); 
 	});
 
 	it("Negative Path Journey - Missing Sub Authorization Header", async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes
Reverting validation message change on expired auth header

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The validation message was incorrectly updated yesterday as no header was provided in the request.  

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-966](https://govukverify.atlassian.net/browse/F2F-966)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-966]: https://govukverify.atlassian.net/browse/F2F-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ