### PR TITLE
F2F-780: Set reserved concurrencies for Lambdas in non-DEV environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 
 # Gov Notify Templates
 The gov-notify-templates directory contains the templates required for sending email notification to the user. The name of the file matches the name of the template in the Gov notify portal for Face to Face Production service. The content of the file has the subject line and the message which should be copied without any changes as it includes gov notify formatting markdown.
+
+
+## Stack deployment in DEV
+
+To deploy an individual stack in the DEV account from a local branch with full DEBUG logging in the lambdas:
+
+```shell
+cd ./deploy
+sam build --parallel
+sam deploy --resolve-s3 --stack-name "YOUR_STACK_NAME" --confirm-changeset --config-env dev --parameter-overrides \
+  "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" L2DynamoStackName=\"infra-l2-dynamo\" L2KMSStackName=\"infra-l2-kms\" PowertoolsLogLevel=\"DEBUG\""
+```
+
+If you need the reserved concurrencies set in DEV then add `ApplyReservedConcurrencyInDev=\"true\"` in to the `--parameter-overrides`.
+Please only do this whilst you need them, if lots of stacks are deployed with these in DEV then deployments will start failing.

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -216,6 +216,9 @@ Conditions:
   DeployAlarms: !Or
     - Condition: IsProdLikeEnvironment
     - !Equals [!Ref DeployAlarmsInNonProdLikeEnvironment, true]
+  DeployConcurrencyAlarms: !And
+    - Condition: DeployAlarms
+    - Condition: ApplyReservedConcurrency
 
 Globals:
   Function:
@@ -532,7 +535,7 @@ Resources:
 
   SessionConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -551,10 +554,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -683,10 +683,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -803,7 +800,7 @@ Resources:
 
   AuthorizationConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -822,10 +819,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -975,7 +969,7 @@ Resources:
 
   DocumentSelectionConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -994,10 +988,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1255,7 +1246,7 @@ Resources:
 
   JsonWebKeysConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -1274,10 +1265,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1410,7 +1398,7 @@ Resources:
 
   GovNotifyConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -1429,10 +1417,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1554,7 +1539,7 @@ Resources:
 
   UserInfoConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -1573,10 +1558,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1893,7 +1875,7 @@ Resources:
 
   YotiCallbackConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -1912,10 +1894,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -3677,7 +3656,7 @@ Resources:
 
   ConcurrencyAlarmDashboard:
     Type: AWS::CloudWatch::Dashboard
-    Condition: DeployAlarms
+    Condition: DeployConcurrencyAlarms
     Properties:
       DashboardName: !Sub '${AWS::StackName}-Concurrency-Alarm-Overview'
       DashboardBody:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -664,7 +664,7 @@ Resources:
 
   TokenConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -54,6 +54,10 @@ Parameters:
     Description: "Reserved concurrency for Lambdas running in non-DEV environments"
     Type: Number
     Default: 20
+  LambdaConcurrencyThreshold:
+    Description: "Threshold for Reserved concurrency running in non-DEV environments"
+    Type: Number
+    Default: 16  #80% of Lambda concurrency
   ApplyReservedConcurrencyInDev:
     Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
     Type: String
@@ -103,7 +107,6 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/redirect"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
       IPVCOREACCOUNT: arn:aws:iam::130355686670:root
-      LAMBDACONCURRENCYTHRESHOLD: 16
     build:
       YOTIBASEURL: "https://yotistub.review-o.build.account.gov.uk"
       YOTISDK: "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
@@ -117,7 +120,6 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-o.build.account.gov.uk/.well-known/jwks.json","clientId":"BD7B2A5D","redirectUri":"https://ipvstub.review-o.build.account.gov.uk/redirect"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
       IPVCOREACCOUNT: arn:aws:iam::457601271792:root
-      LAMBDACONCURRENCYTHRESHOLD: 16
     staging:
       YOTIBASEURL: "https://yotistub.review-o.staging.account.gov.uk"
       YOTISDK: "596d953d-2451-46c8-8553-ebb0d1a75698"
@@ -131,7 +133,6 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.staging.account.gov.uk/.well-known/jwks.json","clientId":"03A5A659-17AA-453F-B905-95D2804823D1","redirectUri":"https://identity.staging.account.gov.uk/credential-issuer/callback?id=f2f"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
       IPVCOREACCOUNT: arn:aws:iam::335257547869:root
-      LAMBDACONCURRENCYTHRESHOLD: 16
     integration:
       YOTIBASEURL: "https://proxy.review-o.integration.account.gov.uk/yoti"
       YOTISDK: "cb78093e-0686-4f86-8e7c-ded6117502e8"
@@ -145,7 +146,6 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json", "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F", "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=f2f"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
       IPVCOREACCOUNT: arn:aws:iam::991138514218:root
-      LAMBDACONCURRENCYTHRESHOLD: 16
     production:
       YOTIBASEURL: "https://proxy.review-o.account.gov.uk/yoti"
       YOTISDK: "81402882-b37c-4348-b336-437cdbb232bb"
@@ -159,7 +159,6 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.account.gov.uk/.well-known/jwks.json", "clientId":"C910A762-4BB2-400D-8F3D-4D7E6C84E342", "redirectUri":"https://identity.account.gov.uk/credential-issuer/callback?id=f2f"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
       IPVCOREACCOUNT: arn:aws:iam::075701497069:root
-      LAMBDACONCURRENCYTHRESHOLD: 16
   TxMAAccounts:
     # EVENTS is used to egress to TxMA.
     dev:
@@ -552,7 +551,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -681,7 +683,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -817,7 +822,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -986,7 +994,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1263,7 +1274,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1415,7 +1429,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1556,7 +1573,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -1892,7 +1912,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCYTHRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -50,6 +50,14 @@ Parameters:
     Type: String
     Default: "f2f-ipv-stub"
     Description: The name of theIPV stub stack deployed.
+  LambdaConcurrency:
+    Description: "Reserved concurrency for Lambdas running in non-DEV environments"
+    Type: Number
+    Default: 20
+  ApplyReservedConcurrencyInDev:
+    Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
+    Type: String
+    Default: "false"
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -174,6 +182,10 @@ Conditions:
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
+  ApplyReservedConcurrency: !Or
+    - !Not
+      - !Condition CreateDevResources
+    - !Equals [!Ref ApplyReservedConcurrencyInDev, "true"]
   IsProdLikeEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -422,6 +434,10 @@ Resources:
       FunctionName: !Sub "F2F-Session-${AWS::StackName}"
       Handler: SessionHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           AUTH_SESSION_TTL_SECS:
@@ -573,6 +589,10 @@ Resources:
       FunctionName: !Sub "Access-Token-${AWS::StackName}"
       Handler: AccessTokenHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AccessTokenHandler
@@ -697,6 +717,10 @@ Resources:
       FunctionName: !Sub "F2F-Authorization-${AWS::StackName}"
       Handler: AuthorizationCodeHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AuthorizationCodeHandler
@@ -829,6 +853,10 @@ Resources:
       FunctionName: !Sub "Document-Selection-${AWS::StackName}"
       Handler: DocumentSelectionHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: DocumentSelectionHandler
@@ -994,6 +1022,10 @@ Resources:
       FunctionName: !Sub "Abort-${AWS::StackName}"
       Handler: AbortHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AbortHandler
@@ -1158,8 +1190,8 @@ Resources:
       CodeUri: ../src/
       Handler: JwksHandler.lambdaHandler
       ReservedConcurrentExecutions: !If
-        - IsProdLikeEnvironment
-        - 80
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Policies:
         - AWSXRayDaemonWriteAccess
@@ -1268,6 +1300,10 @@ Resources:
       Handler: GovNotifyHandler.lambdaHandler
       CodeUri: ../src/
       Timeout: 300
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: GovNotifyHandler
@@ -1416,6 +1452,10 @@ Resources:
       FunctionName: !Sub "User-Info-${AWS::StackName}"
       Handler: UserInfoHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: UserInfoHandler
@@ -1624,6 +1664,10 @@ Resources:
       FunctionName: !Sub "F2F-YotiCallback-${AWS::StackName}"
       Handler: YotiCallbackHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: YotiCallbackHandler


### PR DESCRIPTION

![Screenshot 2023-08-02 at 18 32 31](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/131283983/fc719278-eebc-4a95-9f1b-0d6b7f66e8be)
![Screenshot 2023-08-02 at 18 36 39](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/131283983/df48bdb9-f3c4-4006-a4ff-98aaf900095e)
## Proposed changes

### What changed

Set reserved concurrencies for all lambdas which are deployed in all non-DEV environments. These are required in BUILD since this is the environment used in performance testing. A parameter has been added to allow them to be set when manually deploying in DEV should this be needed, but this must not be default.

### Why did it change

Per requirements on ticket

### Issue tracking

- [F2F-780](https://govukverify.atlassian.net/browse/F2F-780)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-780]: https://govukverify.atlassian.net/browse/F2F-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ