### PR TITLE
Fixed the backend URL in template F2FBackendURL

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -4387,9 +4387,8 @@ Outputs:
   F2FBackendURL:
     Description: "F2F Backend URL"
     Value: !Sub
-      - "https://api-${AWS::StackName}.${DNSSUFFIX}/"
-      - DNSSUFFIX:
-          !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      - "https://${CustomDomainName}"
+      - CustomDomainName: !Ref F2FApiCustomDomainName
     Export:
       Name: !Sub ${AWS::StackName}-F2FBackendURL
   F2FIPVStubExecuteURL:

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -142,16 +142,10 @@ describe("Infra", () => {
 		template.hasOutput("F2FBackendURL", {
 			Value: {
 				"Fn::Sub": [
-					"https://api-${AWS::StackName}.${DNSSUFFIX}/",
+					"https://${CustomDomainName}",
 					{
-						DNSSUFFIX: {
-							"Fn::FindInMap": [
-								"EnvironmentVariables",
-								{
-									Ref: "Environment",
-								},
-								"DNSSUFFIX"
-							],
+						CustomDomainName: {
+							Ref: "F2FApiCustomDomainName"
 						},
 					},
 				],


### PR DESCRIPTION
### What changed
Changed F2FBackendURL output which is used by run-tests.sh script.

### Why did it change
F2FBackendURL in build had incorrect format.

### Issue tracking

- [F2F-977](https://govukverify.atlassian.net/browse/F2F-977)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

Test Results
<img width="325" alt="Screenshot 2023-07-25 at 17 50 40" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/133013208/9dca82cb-5068-4e99-9789-093ef6aa601f">


[F2F-977]: https://govukverify.atlassian.net/browse/F2F-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ