### PR TITLE
abort test fixed in build

### DIFF
--- a/src/tests/api/AbortApi.test.ts
+++ b/src/tests/api/AbortApi.test.ts
@@ -19,9 +19,13 @@ describe("E2E Happy Path /abort enpoint", () => {
 	});
 
 	it("E2E Happy Path Journey - Abort Previously Aborted Session", async () => {
-		const response = await postAbortSession(abortPayload, "e6bf8c21-9e49-46fa-b602-0c0e46055425");
-		expect(response.status).toBe(200);
-		expect(response.data).toBe("Session has already been aborted");
+		expect(sessionId).toBeTruthy();
+		const firstResponse = await postAbortSession(abortPayload, sessionId);
+		expect(firstResponse.request.path).toContain("/redirect?error=access_denied&state=");
+
+		const secondResponse = await postAbortSession(abortPayload, sessionId);
+		expect(secondResponse.status).toBe(200);
+		expect(secondResponse.data).toBe("Session has already been aborted");
 	});
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-983] PR Title` -->

## Proposed changes

Update the tests so they generate a session dynamically then attempt to abort. This will ensure these tests can run in any env.

### What changed

Abort tests now generate a session instead of using a hard coded one. 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

An issue has been identified with the /abort backend tests where the hardcoded session ID exists in dev but not build. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-983](https://govukverify.atlassian.net/browse/F2F-983)

## Checklists

[F2F-983]: https://govukverify.atlassian.net/browse/F2F-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[F2F-983]: https://govukverify.atlassian.net/browse/F2F-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/131249716/c94389df-276c-4548-a7fb-d5d4c5cb97e5)
