### PR TITLE
 [F2F-1026] Update template exports

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -4466,24 +4466,36 @@ Outputs:
     Value: !GetAtt IPVCoreQueueEncryptionKey.Arn
     Export:
       Name: !Sub ${AWS::StackName}-IPVCoreQueueEncryptionKey-arn
+  SessionTableName: 
+    Description: "Name of the Session DynamoDB table"
+    Value:
+      Fn::ImportValue: !Sub "${L2DynamoStackName}-session-table-name"
+    Export:
+      Name: !Sub ${AWS::StackName}-SessionTable-name
   SessionTableARN: 
     Description: "Arn of the Session DynamoDB table"
     Value:
       Fn::ImportValue: !Sub "${L2DynamoStackName}-session-table-arn"
     Export:
       Name: !Sub ${AWS::StackName}-SessionTable-arn
-  PersonIdentityTableARN: 
-    Description: "Arn of the Person Identity DynamoDB table"
-    Value:
-      Fn::ImportValue: !Sub "${L2DynamoStackName}-person-identity-table-arn"
-    Export:
-      Name: !Sub ${AWS::StackName}-PersonIdentityTable-arn
   SessionTableEcryptionARN: 
     Description: "Arn of the SessionTableEncryptionKey"
     Value:
       Fn::ImportValue: !Sub "${L2DynamoStackName}-session-table-key-arn"
     Export:
       Name: !Sub ${AWS::StackName}-SessionTableEncryptionKey-arn
+  PersonIdentityTableName: 
+    Description: "Name of the Person Identity DynamoDB table"
+    Value:
+      Fn::ImportValue: !Sub "${L2DynamoStackName}-person-identity-table-name"
+    Export:
+      Name: !Sub ${AWS::StackName}-PersonIdentityTable-name
+  PersonIdentityTableARN: 
+    Description: "Arn of the Person Identity DynamoDB table"
+    Value:
+      Fn::ImportValue: !Sub "${L2DynamoStackName}-person-identity-table-arn"
+    Export:
+      Name: !Sub ${AWS::StackName}-PersonIdentityTable-arn
   PersonIdentityTableEncryptionARN: 
     Description: "Arn of the PersonTableEncryptionKey"
     Value:


### PR DESCRIPTION
## Proposed changes

### What changed

Updated exports of F2F template to include
- TxMASQSQueue
- TxMAKMSEncryptionKey
- IPVCoreSQSQueue
- IPVCoreQueueEncryptionKey

### Why did it change

This is so that in the new test harness template we can pick up the information about a deployed stack, rather than having to hard code SQS queue and KMS key arns

### Screenshots 
<img width="948" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/193f6519-272f-482a-b1d7-a63277310e45">


### Issue tracking
- [F2F-1026](https://govukverify.atlassian.net/browse/F2F-1026)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-1026]: https://govukverify.atlassian.net/browse/F2F-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ