### PR TITLE
F2F-1045 Update stub to return `sub` and `state`

### DIFF
--- a/f2f-ipv-stub/src/handlers/startF2fCheck.ts
+++ b/f2f-ipv-stub/src/handlers/startF2fCheck.ts
@@ -102,6 +102,8 @@ export const handler = async (
       responseType: "code",
       clientId: config.clientId,
       AuthorizeLocation: `${process.env.OAUTH_FRONT_BASE_URI}/oauth2/authorize?request=${request}&response_type=code&client_id=${config.clientId}`,
+      sub: payload.sub,
+      state: payload.state,
     }),
   };
 };


### PR DESCRIPTION
## Proposed changes

### What changed

The response payload of the call to the sub `/start` endpoint now includes the randomly generated `sub` and `state` in the response payload.

### Why did it change

So that they can be used in the test harness in later calls to find outputs generated from this request

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1045](https://govukverify.atlassian.net/browse/F2F-1045)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-1045]: https://govukverify.atlassian.net/browse/F2F-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ