### PR TITLE
[F2F-1107] Updates name in TxMA F2F_CRI_VC_ISSUED event

### DIFF
--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -239,7 +239,7 @@ export class YotiCallbackProcessor {
 				  throw new AppError(HttpCodesEnum.SERVER_ERROR, "Failed to send to IPV Core", { shouldThrow: true });
 			  }
 
-			  await this.sendYotiEventsToTxMA(documentFields, f2fSession, yotiSessionID, evidence);
+			  await this.sendYotiEventsToTxMA(documentFields, VcNameParts, f2fSession, yotiSessionID, evidence);
 
 			  await this.f2fService.updateSessionAuthState(
 				  f2fSession.sessionId,
@@ -267,7 +267,7 @@ export class YotiCallbackProcessor {
   	return false;
   }
 
-  async sendYotiEventsToTxMA(documentFields: any, f2fSession: any, yotiSessionID: string, evidence: any): Promise<any> {
+  async sendYotiEventsToTxMA(documentFields: any, VcNameParts: Name[], f2fSession: any, yotiSessionID: string, evidence: any): Promise<any> {
 	  // Document type objects to pass into TxMA event F2F_CRI_VC_ISSUED
 
 	  let docName: DocumentNames.PASSPORT | DocumentNames.RESIDENCE_PERMIT | DocumentNames.DRIVING_LICENCE | DocumentNames.NATIONAL_ID;
@@ -347,7 +347,7 @@ export class YotiCallbackProcessor {
 				  ],
 			  },
 			  restricted: {
-				  name: documentFields.full_name, // TODO, TO be updated with nameParts as part of F2F-1000 ticket.
+				  name: VcNameParts,
 				  birthDate: [{ value: documentFields.date_of_birth }],
 				  [docName]: [documentInfo],
 			  },

--- a/src/tests/unit/data/txmaEvent.ts
+++ b/src/tests/unit/data/txmaEvent.ts
@@ -50,7 +50,13 @@ export const TXMA_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,
 	restricted: {
-		"name": "ANGELA ZOE UK SPECIMEN",
+		"name": [{
+			"nameParts": [
+				{ "value": "ANGELA", "type": "GivenName" },
+				{ "value": "ZOE", "type": "GivenName" },
+				{ "value": "UK SPECIMEN", "type": "FamilyName" },
+			],
+		}],
 		"birthDate": [
 			{
 				"value": "1988-12-04",
@@ -71,7 +77,12 @@ export const TXMA_DL_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,
 	restricted: {
-		"name": "LEEROY JENKINS",
+		"name": [{
+			"nameParts": [
+				{ "value": "LEEROY", "type": "GivenName" },
+				{ "value": "JENKINS", "type": "FamilyName" },
+			],
+		}],
 		"birthDate": [
 			{
 				"value": "1988-12-04",
@@ -95,7 +106,13 @@ export const TXMA_EU_DL_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,
 	restricted: {
-		"name": "Erika - Mustermann",
+		"name": [{
+			"nameParts": [
+				{ "value": "Erika", "type": "GivenName" },
+				{ "value": "-", "type": "GivenName" },
+				{ "value": "Mustermann", "type": "FamilyName" },
+			],
+		}],
 		"birthDate": [
 			{
 				"value": "1988-12-04",
@@ -118,7 +135,13 @@ export const TXMA_EEA_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,
 	restricted: {
-		"name": "Wiieke Liselotte De Bruijn",
+		"name": [{
+			"nameParts": [
+				{ "value": "Wiieke", "type": "GivenName" },
+				{ "value": "Liselotte", "type": "GivenName" },
+				{ "value": "De Bruijn", "type": "FamilyName" },
+			],
+		}],
 		"birthDate": [
 			{
 				"value": "1988-12-04",
@@ -140,7 +163,13 @@ export const TXMA_BRP_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,
 	restricted: {
-		"name": "TECH REFRESH ICTHREEMALE",
+		"name": [{
+			"nameParts": [
+				{ "value": "TECH", "type": "GivenName" },
+				{ "value": "REFRESH", "type": "GivenName" },
+				{ "value": "ICTHREEMALE", "type": "FamilyName" },
+			],
+		}],
 		"birthDate": [
 			{
 				"value": "1988-12-04",

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
 import { Logger } from "@aws-lambda-powertools/logger";


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the name value sent in the F2F_CRI_VC_ISSUED event 

### Why did it change

Changes requested

### Screenshots

<img width="724" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/62eb6da5-c863-4282-b19d-33b5bcb4470d">

### Issue tracking
- [F2F-1107](https://govukverify.atlassian.net/browse/F2F-1107)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Other considerations

- Relies on changes from F2F-1000


[F2F-1107]: https://govukverify.atlassian.net/browse/F2F-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ