### PR TITLE
[F2F-1113] Fixing the way we fetch the ipAddress for TXMA events.

### DIFF
--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -59,7 +59,7 @@ export class SessionRequestProcessor {
   async processRequest(event: APIGatewayProxyEvent): Promise<Response> {
   	const deserialisedRequestBody = JSON.parse(event.body as string);
   	const requestBodyClientId = deserialisedRequestBody.client_id;
-  	const clientIpAddress = event.headers["x-forwarded-for"];
+  	const clientIpAddress = event.requestContext.identity?.sourceIp;
 
 
   	let configClient;
@@ -203,10 +203,8 @@ export class SessionRequestProcessor {
   		}
   	}
 
-		const sourceIp = event.requestContext.identity?.sourceIp;
-		
   	try {
-			const coreEventFields = buildCoreEventFields(session, this.environmentVariables.issuer() as string, sourceIp, absoluteTimeNow);
+			const coreEventFields = buildCoreEventFields(session, this.environmentVariables.issuer() as string, clientIpAddress, absoluteTimeNow);
   		await this.f2fService.sendToTXMA({
   			event_name: "F2F_CRI_START",
   			...coreEventFields,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Fixing the way we fetch the ipAddress for TXMA events.

### Why did it change

Bug during regression testing

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1113](https://govukverify.atlassian.net/browse/F2F-1113)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[F2F-1113]: https://govukverify.atlassian.net/browse/F2F-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ