### PR TITLE
F2F-1114: Lambdas Sending Logs to the Wrong Log Groups

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -716,7 +716,7 @@ Resources:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
       FilterPattern: ""
-      LogGroupName: !Ref SessionFunctionLogGroup
+      LogGroupName: !Ref SessionConfigFunctionLogGroup
 
   SessionConfigFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
- SessionConfig function was pointing to wrong log group and now modified to point to the right log group

- [F2F-1114](https://govukverify.atlassian.net/browse/F2F-1114)

Test evidence in ticket above.

[F2F-1114]: https://govukverify.atlassian.net/browse/F2F-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ