### PR TITLE
[F2F-583]Fix for build gov-notify stub pipeline

### DIFF
--- a/gov-notify-stub/template.yaml
+++ b/gov-notify-stub/template.yaml
@@ -148,7 +148,7 @@ Resources:
 
   MockGovNotifyRestApiUsagePlan:
     DependsOn:
-      - "MockGovNotifyRestApi"
+      - MockGovNotifyRestApiStage
     Type: AWS::ApiGateway::UsagePlan
     Properties:
       ApiStages:


### PR DESCRIPTION
Changing the DependsOn target to MockGovNotifyRestApiStage instead of MockGovNotifyRestApi