### PR TITLE
[F2F-672] Pulls out yotiSessionId index change

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -115,21 +115,6 @@ Resources:
               - "clientSessionId"
               - "authSessionState"
             ProjectionType: "INCLUDE"
-        - IndexName: "yotiSessionId-updated-index"
-          KeySchema:
-            - AttributeName: "yotiSessionId"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "subject"
-              - "clientIpAddress"
-              - "state"
-              - "clientId"
-              - "clientSessionId"
-              - "authSessionState"
-              - "expiryDate"
-            ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiryDate
         Enabled: true

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -44,7 +44,7 @@ export class Constants {
 
 	static readonly AUTHORIZATION_CODE_INDEX_NAME = "authCode-updated-index";
 
-	static readonly YOTI_SESSION_ID_INDEX_NAME = "yotiSessionId-updated-index";
+	static readonly YOTI_SESSION_ID_INDEX_NAME = "yotiSessionId-index";
 
 	static readonly TOKEN_EXPIRY_SECONDS = 3600;
 

--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -149,7 +149,7 @@ paths:
   getSessionByYotiId/{tableName}/{yotiSessionId}:
     get:
       operationId: getSessionByIds
-      summary: Get a session by using yotiSessionId-updated-index from DynamoDB
+      summary: Get a session by using yotiSessionId-index from DynamoDB
       description: |
         Endpoint to get a session from DynamoDB using either yotiSessionId as the primary key.
       parameters:
@@ -187,7 +187,7 @@ paths:
           application/json: |
             {
               "TableName":"$input.params('tableName')",
-              "IndexName":"yotiSessionId-updated-index",
+              "IndexName":"yotiSessionId-index",
               "KeyConditionExpression": "yotiSessionId = :yotiSessionId",
               "ExpressionAttributeValues":{
                   ":yotiSessionId":{


### PR DESCRIPTION
## Proposed changes

### What changed

Pulls out yotiSessionId index change

### Why did it change

Pipeline is broken as we are only able to make one index change at a time, but https://github.com/alphagov/di-ipv-cri-f2f-api/pull/183 had two

![image](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/1079c74b-f07e-481c-ac68-36f08a7cb3cc)

### Screenshots

yotiSessionId-updated-index no longer present
![image](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/73dcfaa6-d786-4b99-b5f0-f54bc320d9fd)

Callback API tests passing
<img width="580" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/a627f091-ca84-47e0-bf96-d8aaf7de359a">

### Issue tracking
- [F2F-672](https://govukverify.atlassian.net/browse/F2F-672)


[F2F-672]: https://govukverify.atlassian.net/browse/F2F-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ