### PR TITLE
[F2F-1167] enhance logging and throw error where there is no document_fields

### DIFF
--- a/src/models/YotiPayloads.ts
+++ b/src/models/YotiPayloads.ts
@@ -170,7 +170,7 @@ export interface YotiCompletedSession {
 					};
 				}>;
 			}>;
-			document_fields: {
+			document_fields?: {
 				media: {
 					id: string;
 					type: string;

--- a/src/services/YotiCallbackProcessor.ts
+++ b/src/services/YotiCallbackProcessor.ts
@@ -114,19 +114,20 @@ export class YotiCallbackProcessor {
 
   		const idDocumentsDocumentFields = completedYotiSessionInfo.resources.id_documents[0].document_fields;
   		if (!idDocumentsDocumentFields) {
+  			// If there is no document_fields, yoti have told us there will always be ID_DOCUMENT_TEXT_DATA_CHECK
+  			const documentTextDataCheck = completedYotiSessionInfo.checks.find((check) => check.type === "ID_DOCUMENT_TEXT_DATA_CHECK");
+
 			  this.logger.error({ message: "No document_fields found in completed Yoti Session" }, {
 				  messageCode: MessageCodes.VENDOR_SESSION_MISSING_DATA,
+  				ID_DOCUMENT_TEXT_DATA_CHECK: documentTextDataCheck?.report.recommendation,
 			  });
 			  throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document_fields not populated");
   		}
 
 		  const documentFieldsId = idDocumentsDocumentFields.media.id;
 		  if (!documentFieldsId) {
-  			const documentTextDataCheck = completedYotiSessionInfo.checks.find((check) => check.type === "ID_DOCUMENT_TEXT_DATA_CHECK");
-
 			  this.logger.error({ message: "No media ID found in completed Yoti Session" }, {
 				  messageCode: MessageCodes.VENDOR_SESSION_MISSING_DATA,
-  				documentTextDataCheck:documentTextDataCheck?.report.recommendation,
 			  });
 			  throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document_fields media ID not found");
 		  }

--- a/src/tests/api/CallbackApi.test.ts
+++ b/src/tests/api/CallbackApi.test.ts
@@ -146,6 +146,45 @@ describe("Callback API", () => {
 		validateJwtToken(jwtToken, vcResponseData, "0000");
 	}, 20000);
 
+	it("F2F CRI Callback Endpoint Integration UnHappyPath - yotiMockId: 0160'", async () => {
+		f2fStubPayload.yotiMockID = "0160";
+		const sessionResponse = await startStubServiceAndReturnSessionId(f2fStubPayload);
+		const sessionId = sessionResponse.data.session_id;
+		const sub = sessionResponse.data.sub;
+
+		// Document Selection
+		const response = await postDocumentSelection(dataNonUkPassport, sessionId);
+		expect(response.status).toBe(200);
+		// Authorization
+		const authResponse = await authorizationGet(sessionId);
+		expect(authResponse.status).toBe(200);
+		// // Post Token
+		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri );
+		expect(tokenResponse.status).toBe(200);
+		// Post User Info
+		const userInfoResponse = await userInfoPost("Bearer " + tokenResponse.data.access_token);
+		expect(userInfoResponse.status).toBe(202);
+
+		// Get Yoti Session Id
+		const session = await getSessionById(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME);
+		const yotiSessionId: any = session?.yotiSessionId;
+		console.log(yotiSessionId);
+
+		// Yoti Callback
+		const callbackResponse = await callbackPost(yotiSessionId);
+		expect(callbackResponse.status).toBe(202);
+
+		// Retrieve Verifiable Credential from dequeued SQS queue
+		let sqsMessage;
+		let i = 0;
+		do {
+			sqsMessage = await getDequeuedSqsMessage(sub);
+			i++;
+		} while (i < 5);
+		
+		expect(sqsMessage).toBeUndefined();
+	}, 20000);
+
 	it.each([
 		["0150", dataPassport, "FRANK", "JACOB", "JAMES", "SMITH"],
 		["0151", dataPassport, "FRANK", "JACOB", "JAMES", "SMITH"],

--- a/src/tests/unit/services/YotiCallbackProcessor.test.ts
+++ b/src/tests/unit/services/YotiCallbackProcessor.test.ts
@@ -643,151 +643,193 @@ describe("YotiCallbackProcessor", () => {
 		jest.clearAllMocks();
 	});
 
-	it("Should call getNamesFromYoti if DocumentFields contains both given_name and family_name fields", async () => {
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
-		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+	describe("name checks", () => {
+		it("Should call getNamesFromYoti if DocumentFields contains both given_name and family_name fields", async () => {
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
+			mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
 
-		// @ts-ignore
-		mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+			// @ts-ignore
+			mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
 
-		await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
-		expect(logger.info).toHaveBeenCalledWith("Getting NameParts using Yoti DocumentFields Info");
-	});	
+			await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
+			expect(logger.info).toHaveBeenCalledWith("Getting NameParts using Yoti DocumentFields Info");
+		});	
 
-	it("Should call getNamesFromPersonIdentity if DocumentFields does not contain given_name", async () => {
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
-		mockYotiService.getMediaContent.mockResolvedValueOnce({ 
-			...documentFields,
-			given_names: undefined,
-			full_name: "FrEdErIcK Joseph Flintstone",
-		});
-		mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+		it("Should call getNamesFromPersonIdentity if DocumentFields does not contain given_name", async () => {
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
+			mockYotiService.getMediaContent.mockResolvedValueOnce({ 
+				...documentFields,
+				given_names: undefined,
+				full_name: "FrEdErIcK Joseph Flintstone",
+			});
+			mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
 
-		// @ts-ignore
-		mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+			// @ts-ignore
+			mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
 
 		
-		await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
-		expect(logger.info).toHaveBeenCalledWith("Getting NameParts using F2F Person Identity Info");
-	});	
+			await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
+			expect(logger.info).toHaveBeenCalledWith("Getting NameParts using F2F Person Identity Info");
+		});	
 
-	it("Should use name casing from documentFields when using getNamesFromPersonIdentity", async () => {
-		jest.useFakeTimers();
-		jest.setSystemTime(absoluteTimeNow());
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
-		mockYotiService.getMediaContent.mockResolvedValueOnce({ 
-			...documentFields,
-			given_names: undefined,
-			full_name: "FrEdErIcK Joseph Flintstone",
-		});
-		mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+		it("Should use name casing from documentFields when using getNamesFromPersonIdentity", async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(absoluteTimeNow());
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
+			mockYotiService.getMediaContent.mockResolvedValueOnce({ 
+				...documentFields,
+				given_names: undefined,
+				full_name: "FrEdErIcK Joseph Flintstone",
+			});
+			mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
 
-		// @ts-ignore
-		mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+			// @ts-ignore
+			mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
 
-		await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
+			await mockYotiCallbackProcessor.processRequest(VALID_REQUEST);
 
-		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledWith({
-			sub: "testsub",
-			state: "Y@atr",
-			"https://vocab.account.gov.uk/v1/credentialJWT": [JSON.stringify({
-				"sub":"testsub",
-				"nbf":absoluteTimeNow(),
-				"iss":"https://XXX-c.env.account.gov.uk",
-				"iat":absoluteTimeNow(),
-				"vc":{
-					"@context":[
+			expect(mockF2fService.sendToIPVCore).toHaveBeenCalledWith({
+				sub: "testsub",
+				state: "Y@atr",
+				"https://vocab.account.gov.uk/v1/credentialJWT": [JSON.stringify({
+					"sub":"testsub",
+					"nbf":absoluteTimeNow(),
+					"iss":"https://XXX-c.env.account.gov.uk",
+					"iat":absoluteTimeNow(),
+					"vc":{
+						"@context":[
 					 Constants.W3_BASE_CONTEXT,
 					 Constants.DI_CONTEXT,
-					],
-					"type": [Constants.VERIFIABLE_CREDENTIAL, Constants.IDENTITY_CHECK_CREDENTIAL],
+						],
+						"type": [Constants.VERIFIABLE_CREDENTIAL, Constants.IDENTITY_CHECK_CREDENTIAL],
 					 "credentialSubject":{
-						"name":[
+							"name":[
 								 {
-								"nameParts":[
+									"nameParts":[
 											 {
-										"value":"FrEdErIcK",
-										"type":"GivenName",
+											"value":"FrEdErIcK",
+											"type":"GivenName",
 											 },
 											 {
-										"value":"Joseph",
-										"type":"GivenName",
+											"value":"Joseph",
+											"type":"GivenName",
 											 },
 											 {
-										"value":"Flintstone",
-										"type":"FamilyName",
+											"value":"Flintstone",
+											"type":"FamilyName",
 											 },
-								],
+									],
 								 },
-						],
-						"birthDate":[
+							],
+							"birthDate":[
 								 {
-								"value":"1988-12-04",
+									"value":"1988-12-04",
 								 },
-						],
-						"passport":[
+							],
+							"passport":[
 								 {
-								"documentNumber":"RF9082242",
-								"expiryDate":"2024-11-11",
-								"icaoIssuerCode":"GBR",
+									"documentNumber":"RF9082242",
+									"expiryDate":"2024-11-11",
+									"icaoIssuerCode":"GBR",
 								 },
-						],
+							],
 					 },
 					 "evidence":[
-						{
+							{
 								 "type":"IdentityCheck",
-							"txn":"b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
+								"txn":"b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
 								 "strengthScore":3,
 								 "validityScore":2,
 								 "verificationScore":3,
 								 "checkDetails":[
-								{
+									{
 											 "checkMethod":"vri",
 											 "identityCheckPolicy":"published",
-								},
-								{
+									},
+									{
 											 "checkMethod":"pvr",
 											 "photoVerificationProcessLevel":3,
-								},
+									},
 								 ],
-						},
+							},
 					 ],
-				},
+					},
 		 })],
+			});
+			jest.useRealTimers();
 		});
-		jest.useRealTimers();
+
+		it("Should throw an error of name mismatch between F2F and Yoti DocumentFields", async () => {
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
+			mockYotiService.getMediaContent.mockResolvedValueOnce({ 
+				...documentFields,
+				given_names: undefined,
+				full_name: "Joseph FrEdErIcK Flintstone",
+			});
+			mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+
+			// @ts-ignore
+			mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+
+			return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+				statusCode: HttpCodesEnum.SERVER_ERROR,
+				message: "FullName mismatch between F2F & YOTI",
+			}));
+		});
 	});
 
-	it("Should throw an error of name mismatch between F2F and Yoti DocumentFields", async () => {
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
-		mockYotiService.getMediaContent.mockResolvedValueOnce({ 
-			...documentFields,
-			given_names: undefined,
-			full_name: "Joseph FrEdErIcK Flintstone",
+	describe("yoti session info", () => {
+		it("Throw server error if completed Yoti session can not be found", async () => {
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(undefined);
+
+			return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+				statusCode: HttpCodesEnum.SERVER_ERROR,
+				message: "Yoti Session not found",
+			}));
 		});
-		mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
 
-		// @ts-ignore
-		mockYotiCallbackProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+		it("Throws server error if session in Yoti is not completed", async () => {
+			const completedYotiSessionClone = { ...completedYotiSession, state: "ONGOING" };
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSessionClone);
+			mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+	
+			return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+				statusCode: HttpCodesEnum.SERVER_ERROR,
+				message: "Yoti Session not complete",
+			}));
+		});
 
-		return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
-			statusCode: HttpCodesEnum.SERVER_ERROR,
-			message: "FullName mismatch between F2F & YOTI",
-		}));
-	});
+		it("Throws server error if session in Yoti does not contain document fields", () => {
+			const completedYotiSessionClone = JSON.parse(JSON.stringify(completedYotiSession));
+			delete completedYotiSessionClone.resources.id_documents[0].document_fields;
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSessionClone);
+			mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+	
+			return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+				statusCode: HttpCodesEnum.SERVER_ERROR,
+				message: "Yoti document_fields not populated",
+			}));
+		});
 
-	it("Throw server error if completed Yoti session can not be found", async () => {
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(undefined);
-
-		return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
-			statusCode: HttpCodesEnum.SERVER_ERROR,
-			message: "Yoti Session not found",
-		}));
+		it("Throws server error if session in Yoti does not contain media ID", () => {
+			const completedYotiSessionClone = JSON.parse(JSON.stringify(completedYotiSession));
+			delete completedYotiSessionClone.resources.id_documents[0].document_fields.media.id;
+			mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSessionClone);
+			mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+			mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+	
+			return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+				statusCode: HttpCodesEnum.SERVER_ERROR,
+				message: "Yoti document_fields media ID not found",
+			}));
+		});
 	});
 
 	it("Throw server error if F2F Session can not be found", async () => {
@@ -838,20 +880,7 @@ describe("YotiCallbackProcessor", () => {
 		}));
 	});
 
-	it("Throws server error if session in Yoti is not completed", async () => {
-		completedYotiSession.state = "ONGOING";
-		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
-		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
-		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
-
-		return expect(mockYotiCallbackProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
-			statusCode: HttpCodesEnum.SERVER_ERROR,
-			message: "Yoti Session not complete",
-		}));
-	});
-
 	it("Throws server error if signGeneratedVerifiableCredentialJwt returns empty string", async () => {
-		completedYotiSession.state = "COMPLETED";
 		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
 		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
 		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
@@ -865,7 +894,6 @@ describe("YotiCallbackProcessor", () => {
 	});
 
 	it("Returns server error response if signGeneratedVerifiableCredentialJwt throws error", async () => {
-		completedYotiSession.state = "COMPLETED";
 		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
 		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
 		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
@@ -879,7 +907,6 @@ describe("YotiCallbackProcessor", () => {
 	});
 
 	it("Throws server error if generateVerifiableCredentialJwt returns empty string", async () => {
-		completedYotiSession.state = "COMPLETED";
 		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(completedYotiSession);
 		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
 		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);

--- a/yoti-stub/src/services/YotiRequestProcessor.ts
+++ b/yoti-stub/src/services/YotiRequestProcessor.ts
@@ -848,23 +848,23 @@ export class YotiRequestProcessor {
                         VALID_RESPONSE_NFC_0150.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0150.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_ONLY_FULLNAME_MEDIA_ID);
                         return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0150));
 
-										case '0151': // UK Passport Success - Only FullName & GivenName in DocumentFields
-											logger.debug(JSON.stringify(yotiSessionRequest));
-											const VALID_RESPONSE_NFC_0151 = JSON.parse(JSON.stringify(VALID_RESPONSE_NFC));
+                    case '0151': // UK Passport Success - Only FullName & GivenName in DocumentFields
+                        logger.debug(JSON.stringify(yotiSessionRequest));
+                        const VALID_RESPONSE_NFC_0151 = JSON.parse(JSON.stringify(VALID_RESPONSE_NFC));
 
-											VALID_RESPONSE_NFC_0151.session_id = sessionId;
-											VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id = sessionId;
-											VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_GIVEN_NAME_MEDIA_ID);
-											return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0151));
+                        VALID_RESPONSE_NFC_0151.session_id = sessionId;
+                        VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id = sessionId;
+                        VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0151.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_GIVEN_NAME_MEDIA_ID);
+                        return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0151));
 
-										case '0152': // UK Passport Success - Only FullName & FamilyName in DocumentFields
-											logger.debug(JSON.stringify(yotiSessionRequest));
-											const VALID_RESPONSE_NFC_0152 = JSON.parse(JSON.stringify(VALID_RESPONSE_NFC));
+                    case '0152': // UK Passport Success - Only FullName & FamilyName in DocumentFields
+                        logger.debug(JSON.stringify(yotiSessionRequest));
+                        const VALID_RESPONSE_NFC_0152 = JSON.parse(JSON.stringify(VALID_RESPONSE_NFC));
 
-											VALID_RESPONSE_NFC_0152.session_id = sessionId;
-											VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id = sessionId;
-											VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_FAMILY_NAME_MEDIA_ID);
-											return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0152));
+                        VALID_RESPONSE_NFC_0152.session_id = sessionId;
+                        VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id = sessionId;
+                        VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0152.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_FAMILY_NAME_MEDIA_ID);
+                        return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0152));
 
                     case '0153': // UK Passport Success - Wrong Split of GivenNames in DocumentFields
                         logger.debug(JSON.stringify(yotiSessionRequest));
@@ -875,6 +875,33 @@ export class YotiRequestProcessor {
                         VALID_RESPONSE_NFC_0153.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_RESPONSE_NFC_0153.resources.id_documents[0].document_fields.media.id, UK_PASSPORT_GIVEN_NAME_WRONG_SPLIT);
                         return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0153));
 
+                    case '0160': // UK Passport - manual text extraction failed
+                        logger.debug(JSON.stringify(yotiSessionRequest));
+                        const VALID_RESPONSE_NFC_0160 = JSON.parse(JSON.stringify(VALID_RESPONSE_NFC));
+
+                        delete VALID_RESPONSE_NFC_0160.resources.id_documents[0].document_fields;
+                        VALID_RESPONSE_NFC_0160.checks = [
+                            ...VALID_RESPONSE_NFC_0160.checks,
+                            {
+                                type: "ID_DOCUMENT_TEXT_DATA_CHECK",
+                                id: "5c62d223-a1a4-44fa-a5df-0e0bda404ff6",
+                                state: "DONE",
+                                resources_used: [
+                                    "034e9981-bd92-4b8f-8e6f-081516a52f00"
+                                ],
+                                generated_media: [],
+                                report: {
+                                    "recommendation": {
+                                        "value": "NOT_AVAILABLE",
+                                        "reason": "PHOTO_TOO_BLURRY"
+                                    },
+                                    "breakdown": []
+                                },
+                                created: "2023-05-23T14:54:00Z",
+                                last_updated: "2023-05-23T14:55:32Z"
+                            },
+                        ];
+                        return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_RESPONSE_NFC_0160));
                     default:
                         return undefined;
                 }


### PR DESCRIPTION
## Proposed changes

### What changed

Throw error where there is no document_fields, enhance logging so we can see why this happened

Mock updated with data from https://drive.google.com/drive/folders/1iEsLz1qOIDdcyWE-asx4BbfOD3Sv3PMf

### Why did it change

To handle production error and help us to debug it in the future

![image](https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/9652bd9b-7ea1-4272-8011-f173813e8ee7)

### Screenshots 
<img width="847" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/0583a84f-8f7c-47f3-b87a-3cd7995b019e">

### Issue tracking
- [F2F-1167](https://govukverify.atlassian.net/browse/F2F-1167)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-1167]: https://govukverify.atlassian.net/browse/F2F-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ