### PR TITLE
Additional documentTypes in TxMA Validation

### DIFF
--- a/src/tests/api/CallbackApi.test.ts
+++ b/src/tests/api/CallbackApi.test.ts
@@ -194,14 +194,21 @@ describe("Callback API", () => {
 		validateJwtTokenNamePart(jwtToken, givenName1, givenName2, givenName3, familyName + yotiMockId);
 	}, 20000);
 
-	it("F2F CRI Callback Endpoint TxMA Validation", async () => {
-		f2fStubPayload.yotiMockID = "0000";
+	it.each([
+		["0000", dataUkDrivingLicence],
+		["0101", dataPassport],
+		["0200", dataNonUkPassport],
+		["0300", dataBrp],
+		["0400", dataEuDrivingLicence],
+		["0500", dataEeaIdCard],
+	])("F2F CRI Callback Endpoint TxMA Validation", async (yotiMockId: string, docSelectionData:any) => {
+		f2fStubPayload.yotiMockID = yotiMockId;
 		const sessionResponse = await startStubServiceAndReturnSessionId(f2fStubPayload);
 		const sessionId = sessionResponse.data.session_id;
 		const sub = sessionResponse.data.sub;
 
 		// Document Selection
-		const response = await postDocumentSelection(dataPassport, sessionId);
+		const response = await postDocumentSelection(docSelectionData, sessionId);
 		expect(response.status).toBe(200);
 		// Authorization
 		const authResponse = await authorizationGet(sessionId);
@@ -227,7 +234,7 @@ describe("Callback API", () => {
 		do {
 			sqsMessage = await getSqsEventList("txma/", sessionId, 7);
 		} while (!sqsMessage);
-		await validateTxMAEventData(sqsMessage);
+		await validateTxMAEventData(sqsMessage, yotiMockId);
 
 	}, 20000);
 

--- a/src/tests/data/F2F_CRI_VC_ISSUED_00_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_00_SCHEMA.json
@@ -1,0 +1,254 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "drivingPermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "personalNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                },
+                                "issuedBy": {
+                                    "type": "string"
+                                },
+                                "issueDate": {
+                                    "type": "string"
+                                },
+                                "fullAddress": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "personalNumber",
+                                "expiryDate",
+                                "issuingCountry",
+                                "issuedBy",
+                                "issueDate",
+                                "fullAddress"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "drivingPermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_CRI_VC_ISSUED_01_SCHEMA .json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_01_SCHEMA .json
@@ -1,0 +1,227 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "passport": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "documentNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "icaoIssuerCode": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "documentNumber",
+                                "expiryDate",
+                                "icaoIssuerCode"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "passport"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_CRI_VC_ISSUED_02_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_02_SCHEMA.json
@@ -1,0 +1,227 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "passport": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "documentNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "icaoIssuerCode": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "documentNumber",
+                                "expiryDate",
+                                "icaoIssuerCode"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "passport"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_CRI_VC_ISSUED_03_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_03_SCHEMA.json
@@ -1,0 +1,246 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "residencePermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "documentNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "issueDate": {
+                                    "type": "string"
+                                },
+                                "icaoIssuerCode": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "documentNumber",
+                                "expiryDate",
+                                "issueDate",
+                                "icaoIssuerCode"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "residencePermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_CRI_VC_ISSUED_04_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_04_SCHEMA.json
@@ -1,0 +1,250 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "drivingPermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "personalNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                },
+                                "issuedBy": {
+                                    "type": "string"
+                                },
+                                "issueDate": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "personalNumber",
+                                "expiryDate",
+                                "issuingCountry",
+                                "issuedBy",
+                                "issueDate"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "drivingPermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_CRI_VC_ISSUED_05_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_VC_ISSUED_05_SCHEMA.json
@@ -1,0 +1,246 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "previous_govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "txn": {
+                                    "type": "string"
+                                },
+                                "strengthScore": {
+                                    "type": "integer"
+                                },
+                                "validityScore": {
+                                    "type": "integer"
+                                },
+                                "verificationScore": {
+                                    "type": "integer"
+                                },
+                                "checkDetails": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "identityCheckPolicy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "identityCheckPolicy"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "checkMethod": {
+                                                    "type": "string"
+                                                },
+                                                "biometricVerificationProcessLevel": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "checkMethod",
+                                                "biometricVerificationProcessLevel"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "txn",
+                                "strengthScore",
+                                "validityScore",
+                                "verificationScore",
+                                "checkDetails"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "previous_govuk_signin_journey_id",
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "nameParts": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "value": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "value",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "nameParts"
+                            ]
+                        }
+                    ]
+                },
+                "birthDate": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    ]
+                },
+                "idCard": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "documentNumber": {
+                                    "type": "string"
+                                },
+                                "expiryDate": {
+                                    "type": "string"
+                                },
+                                "issueDate": {
+                                    "type": "string"
+                                },
+                                "icaoIssuerCode": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "documentNumber",
+                                "expiryDate",
+                                "issueDate",
+                                "icaoIssuerCode"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "birthDate",
+                "idCard"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_00_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_00_SCHEMA.json
@@ -1,0 +1,143 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "drivingPermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "drivingPermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_01_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_01_SCHEMA.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "passport": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "passport"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_02_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_02_SCHEMA.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "passport": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "passport"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_03_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_03_SCHEMA.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "residencePermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "residencePermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_04_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_04_SCHEMA.json
@@ -1,0 +1,143 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "drivingPermit": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "drivingPermit"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/F2F_YOTI_START_05_SCHEMA.json
+++ b/src/tests/data/F2F_YOTI_START_05_SCHEMA.json
@@ -1,0 +1,143 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "ip_address",
+                "govuk_signin_journey_id"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "txn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "txn"
+                            ]
+                        }
+                    ]
+                },
+                "post_office_details": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "post_code": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "address",
+                                "post_code",
+                                "location"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence",
+                "post_office_details"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "idCard": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "documentType": {
+                                    "type": "string"
+                                },
+                                "issuingCountry": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "documentType",
+                                "issuingCountry"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "idCard"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -280,26 +280,44 @@ export async function getSqsEventList(folder: string, prefix: string, txmaEventS
 }
 
 
-export async function validateTxMAEventData(keyList: any): Promise<any> {
+export async function validateTxMAEventData(keyList: any, yotiMockID: any): Promise<any> {
 	let i:any;
+	const yotiMockIdPrefix = yotiMockID.slice(0, 2);
 	for (i = 0; i < keyList.length; i++) {
 		const getObjectResponse = await HARNESS_API_INSTANCE.get("/object/" + keyList[i], {});
 		console.log(JSON.stringify(getObjectResponse.data, null, 2));
 		let valid = true;
-		import("../data/" + getObjectResponse.data.event_name + "_SCHEMA.json" )
-			.then((jsonSchema) => {
-				const validate = ajv.compile(jsonSchema);
-				valid = validate(getObjectResponse.data);
-				if (!valid) {
-					console.error(getObjectResponse.data.event_name + " Event Errors: " + JSON.stringify(validate.errors));
-				}
-			})
-			.catch((err) => {
-				console.log(err.message);
-			})
-			.finally(() => {
-				expect(valid).toBe(true);
-			});
+		if (getObjectResponse.data.event_name === "F2F_CRI_VC_ISSUED" || getObjectResponse.data.event_name === "F2F_YOTI_START") {
+			import("../data/" + getObjectResponse.data.event_name + "_" + yotiMockIdPrefix + "_SCHEMA.json" )
+				.then((jsonSchema) => {
+					const validate = ajv.compile(jsonSchema);
+					valid = validate(getObjectResponse.data);
+					if (!valid) {
+						console.error(getObjectResponse.data.event_name + " Event Errors: " + JSON.stringify(validate.errors));
+					}
+				})
+				.catch((err) => {
+					console.log(err.message);
+				})
+				.finally(() => {
+					expect(valid).toBe(true);
+				});
+		} else {
+			import("../data/" + getObjectResponse.data.event_name + "_SCHEMA.json" )
+				.then((jsonSchema) => {
+					const validate = ajv.compile(jsonSchema);
+					valid = validate(getObjectResponse.data);
+					if (!valid) {
+						console.error(getObjectResponse.data.event_name + " Event Errors: " + JSON.stringify(validate.errors));
+					}
+				})
+				.catch((err) => {
+					console.log(err.message);
+				})
+				.finally(() => {
+					expect(valid).toBe(true);
+				});
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Additional documentTypes added to TxMA validation tests

### Why did it change

Additional coverage in BE pipeline regression tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1173](https://govukverify.atlassian.net/browse/F2F-1173)

