### PR TITLE
[KIWI-1243] - Include all necessary states for ReminderEmail

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2104,7 +2104,7 @@ Resources:
         ScheduledEvent:
           Type: Schedule
           Properties:
-            Schedule: cron(0 13 ? * MON-FRI *)  # This will run at 10 am on weekdays (Monday to Friday)
+            Schedule: cron(0 13 ? * MON-FRI *)  # This will run at 1 pm on weekdays (Monday to Friday) - To be changed back to 10am soon
 
 
     Metadata: # Manage esbuild properties

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2104,7 +2104,7 @@ Resources:
         ScheduledEvent:
           Type: Schedule
           Properties:
-            Schedule: cron(0 10 ? * MON-FRI *)  # This will run at 10 am on weekdays (Monday to Friday)
+            Schedule: cron(0 13 ? * MON-FRI *)  # This will run at 10 am on weekdays (Monday to Friday)
 
 
     Metadata: # Manage esbuild properties

--- a/src/services/F2fService.ts
+++ b/src/services/F2fService.ts
@@ -235,32 +235,32 @@ export class F2fService {
 	}
 
 	async getSessionsByAuthSessionStates(authSessionStates: string[]): Promise<Array<Record<string, any>>> {
-    const promises = authSessionStates.map(async (authSessionState) => {
-        const params: QueryCommandInput = {
-            TableName: this.tableName,
-            IndexName: Constants.AUTH_SESSION_STATE_INDEX_NAME,
-            KeyConditionExpression: "authSessionState = :authSessionState",
-            ExpressionAttributeValues: {
-                ":authSessionState": authSessionState,
-            },
-        };
+		const promises = authSessionStates.map(async (authSessionState) => {
+			const params: QueryCommandInput = {
+				TableName: this.tableName,
+				IndexName: Constants.AUTH_SESSION_STATE_INDEX_NAME,
+				KeyConditionExpression: "authSessionState = :authSessionState",
+				ExpressionAttributeValues: {
+					":authSessionState": authSessionState,
+				},
+			};
 
-        const sessionItems = await this.dynamo.query(params);
+			const sessionItems = await this.dynamo.query(params);
 
-        return sessionItems?.Items || [];
-    });
+			return sessionItems?.Items || [];
+		});
 
-    const results = await Promise.all(promises);
+		const results = await Promise.all(promises);
     
-    // Merge the results into a single array
-    const mergedResults = results.reduce((acc, items) => acc.concat(items), []);
+		// Merge the results into a single array
+		const mergedResults = results.reduce((acc, items) => acc.concat(items), []);
 
-    // Filter out any records that have hit TTL
-    const filteredItems = mergedResults.filter(item => {
-        return item.expiryDate > absoluteTimeNow();
-    });
+		// Filter out any records that have hit TTL
+		const filteredItems = mergedResults.filter(item => {
+			return item.expiryDate > absoluteTimeNow();
+		});
 
-    return filteredItems;
+		return filteredItems;
 	}
 
 

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -34,10 +34,10 @@ export class ReminderEmailProcessor {
   			return { statusCode: HttpCodesEnum.OK, body: "No Session Records matching state" };
   		}
  
-			const filteredSessions = F2FSessionCreatedRecords.filter(
-				({ createdDate, reminderEmailSent }) =>
-					(createdDate <= absoluteTimeNow() - 5 * 24 * 60 * 60)  && !reminderEmailSent
-			);
+  		const filteredSessions = F2FSessionCreatedRecords.filter(
+  			({ createdDate, reminderEmailSent }) =>
+  				(createdDate <= absoluteTimeNow() - 5 * 24 * 60 * 60) && !reminderEmailSent,
+  		);
 
   		if (filteredSessions.length === 0) {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]} older than 5 days`);

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -26,22 +26,22 @@ export class ReminderEmailProcessor {
 
   async processRequest(): Promise<Response> {
   	try {
-  		const F2FSessionCreatedRecords = await this.f2fService.getSessionsByAuthSessionState(AuthSessionState.F2F_YOTI_SESSION_CREATED);
+  		const F2FSessionCreatedRecords = await this.f2fService.getSessionsByAuthSessionStates([AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]);
 
-  		if (F2FSessionCreatedRecords.length === 0) {
-  			this.logger.info(`No users with session state ${AuthSessionState.F2F_YOTI_SESSION_CREATED}`);
-  			return { statusCode: HttpCodesEnum.OK, body: "No F2F_YOTI_SESSION_CREATED Records" };
-  		}
+			if (F2FSessionCreatedRecords.length === 0) {
+				this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]}`);
+				return { statusCode: HttpCodesEnum.OK, body: "No Session Records matching state" };
+			}
  
   		const filteredSessions = F2FSessionCreatedRecords.filter(
   			({ createdDate, reminderEmailSent }) =>
   				createdDate >= Date.now() - 5 * 24 * 60 * 60 * 1000 && !reminderEmailSent,
   		);
 
-  		if (filteredSessions.length === 0) {
-  			this.logger.info(`No users with session state ${AuthSessionState.F2F_YOTI_SESSION_CREATED} older than 5 days`);
-  			return { statusCode: HttpCodesEnum.OK, body: "No F2F_YOTI_SESSION_CREATED Sessions older than 5 days" };
-  		}
+			if (filteredSessions.length === 0) {
+				this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]} older than 5 days`);
+				return { statusCode: HttpCodesEnum.OK, body: "No Sessions older than 5 days" };
+			}
 
   		this.logger.info("Total num. of users to send reminder emails to:", { numOfUsers: filteredSessions.length });
 

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -210,10 +210,11 @@ describe("F2f Service", () => {
 		}));
 	});
 
-	it("should throw error when session items are not found by auth session state", async () => {
+	it("should return empty array when ession items are not found by auth session state", async () => {
 		mockDynamoDbClient.query = jest.fn().mockResolvedValue({ Items: [] });
 
-		await expect(f2fService.getSessionsByAuthSessionState("F2F_SESSION_CREATED")).rejects.toThrow("Error retrieving Sessions by authSessionState");
+		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_SESSION_STARTED"]);
+		expect(result).toEqual([]);
 	});
 
 	it("should not return any session Items if the expiryDate has passed", async () => {
@@ -230,7 +231,7 @@ describe("F2f Service", () => {
 			],
 		});
 
-		const result = await f2fService.getSessionsByAuthSessionState("F2F_SESSION_STARTED");
+		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_SESSION_STARTED"]);
 		expect(result).toEqual([]);
 	});
 
@@ -250,14 +251,14 @@ describe("F2f Service", () => {
 			}],
 		});
 
-		const result = await f2fService.getSessionsByAuthSessionState("F2F_SESSION_STARTED");
+		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED"]);
 		expect(result).toEqual([{ sessionId: "SESSID", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTWO", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTHREE", expiryDate: expect.any(Number) }]);
-		expect(mockDynamoDbClient.query).toHaveBeenCalledWith(expect.objectContaining({
-			KeyConditionExpression: "authSessionState = :authSessionState",
-			ExpressionAttributeValues: {
-				":authSessionState": "F2F_SESSION_STARTED",
-			},
-		}));
+		expect(mockDynamoDbClient.query).toHaveBeenCalledWith({
+			"ExpressionAttributeValues": {":authSessionState": "F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED"},
+			"IndexName": "authSessionState-index",
+			"KeyConditionExpression": "authSessionState = :authSessionState",
+			"TableName": "SESSIONTABLE"
+		});
 	});
 
 

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -210,7 +210,7 @@ describe("F2f Service", () => {
 		}));
 	});
 
-	it("should return empty array when ession items are not found by auth session state", async () => {
+	it("should return empty array when session items are not found by auth session state", async () => {
 		mockDynamoDbClient.query = jest.fn().mockResolvedValue({ Items: [] });
 
 		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_SESSION_STARTED"]);
@@ -254,10 +254,10 @@ describe("F2f Service", () => {
 		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED"]);
 		expect(result).toEqual([{ sessionId: "SESSID", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTWO", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTHREE", expiryDate: expect.any(Number) }]);
 		expect(mockDynamoDbClient.query).toHaveBeenCalledWith({
-			"ExpressionAttributeValues": {":authSessionState": "F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED"},
+			"ExpressionAttributeValues": { ":authSessionState": "F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED" },
 			"IndexName": "authSessionState-index",
 			"KeyConditionExpression": "authSessionState = :authSessionState",
-			"TableName": "SESSIONTABLE"
+			"TableName": "SESSIONTABLE",
 		});
 	});
 

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -251,10 +251,26 @@ describe("F2f Service", () => {
 			}],
 		});
 
-		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED"]);
-		expect(result).toEqual([{ sessionId: "SESSID", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTWO", expiryDate: expect.any(Number) }, { sessionId: "SESSIDTHREE", expiryDate: expect.any(Number) }]);
-		expect(mockDynamoDbClient.query).toHaveBeenCalledWith({
-			"ExpressionAttributeValues": { ":authSessionState": "F2F_YOTI_SESSION_CREATED, F2F_AUTH_CODE_ISSUED, F2F_ACCESS_TOKEN_ISSUED" },
+		const result = await f2fService.getSessionsByAuthSessionStates(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
+		expect(result).toEqual([
+			{ "expiryDate": expect.any(Number), "sessionId": "SESSID" },
+			{ "expiryDate": expect.any(Number), "sessionId": "SESSIDTWO" },
+			{ "expiryDate": expect.any(Number), "sessionId": "SESSIDTHREE" },
+		]);
+		expect(mockDynamoDbClient.query).toHaveBeenNthCalledWith(1, {
+			"ExpressionAttributeValues": { ":authSessionState": "F2F_YOTI_SESSION_CREATED" },
+			"IndexName": "authSessionState-index",
+			"KeyConditionExpression": "authSessionState = :authSessionState",
+			"TableName": "SESSIONTABLE",
+		});
+		expect(mockDynamoDbClient.query).toHaveBeenNthCalledWith(2, {
+			"ExpressionAttributeValues": { ":authSessionState": "F2F_AUTH_CODE_ISSUED" },
+			"IndexName": "authSessionState-index",
+			"KeyConditionExpression": "authSessionState = :authSessionState",
+			"TableName": "SESSIONTABLE",
+		});
+		expect(mockDynamoDbClient.query).toHaveBeenNthCalledWith(3, {
+			"ExpressionAttributeValues": { ":authSessionState": "F2F_ACCESS_TOKEN_ISSUED" },
 			"IndexName": "authSessionState-index",
 			"KeyConditionExpression": "authSessionState = :authSessionState",
 			"TableName": "SESSIONTABLE",

--- a/src/tests/unit/services/ReminderEmailProcessor.test.ts
+++ b/src/tests/unit/services/ReminderEmailProcessor.test.ts
@@ -17,29 +17,29 @@ describe("ReminderEmailProcessor", () => {
 
 	const F2FSessionsWithYotiSession = [
 		{
-			createdDate: 1703429155023,
+			createdDate: 1686327580350,
 			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a4e",
 			reminderEmailSent: true,
 			authSessionState: "F2F_YOTI_SESSION_CREATED",
 		},
 		{
-			createdDate: 1681905531361,
+			createdDate: 1177408,
 			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a48",
 			authSessionState: "F2F_YOTI_SESSION_CREATED",
 		},
 		{
-			createdDate: 1703429155023,
+			createdDate: 1695302248,
 			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a4h",
 			authSessionState: "F2F_YOTI_SESSION_CREATED",
 		},
 		{
-			createdDate: 1703429155023,
+			createdDate: 1091008,
 			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a47",
 			reminderEmailSent: false,
 			authSessionState: "F2F_YOTI_SESSION_CREATED",
 		},
 		{
-			createdDate: 1681905531361,
+			createdDate: 1695284750,
 			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a43",
 			authSessionState: "F2F_YOTI_SESSION_CREATED",
 		},
@@ -98,9 +98,15 @@ describe("ReminderEmailProcessor", () => {
 		personIdentityItem = getPersonIdentityItem();
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
-	});
+	beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1695808788)); // Sep 27 2023 08:53:12 GMT+0000
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
 
 	it("should process request successfully", async () => {
     
@@ -114,7 +120,7 @@ describe("ReminderEmailProcessor", () => {
 		expect(result).toEqual({ statusCode: 200, body: "Success" });
 		expect(mockLogger.info).toHaveBeenCalledWith("Total num. of users to send reminder emails to:", { numOfUsers: 2 });
 		expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
-		expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a4h", "PERSONIDENTITYTABLE");
+		expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
 		expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
 		expect(mockF2fService.sendToGovNotify).toHaveBeenCalledWith({
 			Message: {
@@ -122,7 +128,7 @@ describe("ReminderEmailProcessor", () => {
 				messageType: "REMINDER_EMAIL",
 			},
 		});
-		expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a4h", true);
+		expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
 		expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
 	});
 

--- a/src/tests/unit/services/ReminderEmailProcessor.test.ts
+++ b/src/tests/unit/services/ReminderEmailProcessor.test.ts
@@ -99,14 +99,14 @@ describe("ReminderEmailProcessor", () => {
 	});
 
 	beforeEach(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date(1695808788)); // Sep 27 2023 08:53:12 GMT+0000
-  });
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date(1695808788)); // Sep 27 2023 08:53:12 GMT+0000
+	});
 
-  afterEach(() => {
-    jest.useRealTimers();
-    jest.resetAllMocks();
-  });
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.resetAllMocks();
+	});
 
 	it("should process request successfully", async () => {
     


### PR DESCRIPTION
### What changed

Update the DB Query for ReminderEmail to include all states the F2F Session could be from the point where the user has started a F2F Journey but has not aborted their journey and have not yet visited the PO

<img width="1419" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/13416125/144b47ed-c96c-4515-9ade-0c00b7808757">
