### PR TITLE
[KIWI-1138]Remove Unused authCode-index

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -91,18 +91,6 @@ Resources:
               - "clientSessionId"
               - "expiryDate"
             ProjectionType: "INCLUDE"
-        - IndexName: "authCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-              - "clientId"
-              - "authSessionState"
-              - "clientSessionId"
-            ProjectionType: "INCLUDE"
         - IndexName: "yotiSessionId-index"
           KeySchema:
             - AttributeName: "yotiSessionId"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Removing the Unused authCode-index

### Why did it change

Tech debt

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1138](https://govukverify.atlassian.net/browse/KIWI-1138)

Evidence:
Before indexes: 
<img width="641" alt="Screenshot 2023-09-25 at 12 29 35" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/115095929/6ad841ab-36d5-4b5b-8fb7-1d594c7f4dd9">

After index list:

<img width="645" alt="Screenshot 2023-09-25 at 12 30 35" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/115095929/15e6fdb0-3f41-4743-b6a2-7e8e6d4c6685">



[KIWI-1138]: https://govukverify.atlassian.net/browse/KIWI-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ