### PR TITLE
[KIWI-1254] fix hour cycle

### DIFF
--- a/src/services/ThankYouEmailProcessor.ts
+++ b/src/services/ThankYouEmailProcessor.ts
@@ -88,7 +88,7 @@ export class ThankYouEmailProcessor {
   		const yotiSessionCreatedAt = yotiSessionInfo.resources.id_documents[0].created_at;
   		const dateObject = new Date(yotiSessionCreatedAt);
   		const postOfficeDateOfVisit = dateObject.toLocaleDateString("en-GB", { year: "numeric", month: "long", day: "numeric" });
-  		const postOfficeTimeOfVisit = dateObject.toLocaleTimeString("en-GB", { hour: "numeric", minute: "numeric", hour12: true });
+  		const postOfficeTimeOfVisit = dateObject.toLocaleTimeString("en-GB", { hour: "numeric", minute: "numeric", hourCycle: "h12" });
 
   		this.logger.info("Post office visit details", { postOfficeDateOfVisit, postOfficeTimeOfVisit });
 

--- a/src/tests/unit/services/ThankYouEmailProcessor.test.ts
+++ b/src/tests/unit/services/ThankYouEmailProcessor.test.ts
@@ -301,7 +301,7 @@ describe("ThankYouEmailProcessor", () => {
 			await thankYouEmailProcessor.processRequest({ session_id: sessionId, topic: "session_completion" });
 
 			expect(Date.prototype.toLocaleDateString).toHaveBeenCalledWith("en-GB", { year: "numeric", month: "long", day: "numeric" });
-			expect(Date.prototype.toLocaleTimeString).toHaveBeenCalledWith("en-GB", { hour: "numeric", minute: "numeric", hour12: true });
+			expect(Date.prototype.toLocaleTimeString).toHaveBeenCalledWith("en-GB", { hour: "numeric", minute: "numeric", hourCycle: "h12" });
 			expect(mockF2fService.sendToTXMA).toHaveBeenCalledWith({
 				event_name: "F2F_DOCUMENT_UPLOADED",
 				client_id: "ipv-core-stub",


### PR DESCRIPTION
## Proposed changes

### What changed

Use` hourCycle` instead of `hour12` as it seems that en-GB has a default hour cycle of 11/23 meaning that it considers 11 the end of a cycle rather than 12 - see docs https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options

### Why did it change

So that we shown 12pm rather than 0pm 

### Issue tracking
- [KIWI-1254](https://govukverify.atlassian.net/browse/KIWI-1254)

### Screenshots
Before 
<img width="692" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/d0709515-e0f8-4420-93e0-802284b592c3">
<img width="647" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/092fed7f-681d-4e21-b0e9-4cb52381994c">


After 
<img width="711" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/8c6f5327-4181-45ef-9159-e73b6de3e97e">
<img width="654" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-api/assets/40401118/2ef6f8fd-cffd-43f3-a746-eb2130ff9fbd">


[KIWI-1254]: https://govukverify.atlassian.net/browse/KIWI-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ