### PR TITLE
[KIWI-1275] Adds GOVUKNOTIFYREMINDERTEMPLATEID env var to integration env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -150,6 +150,7 @@ Mappings:
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
+      GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json", "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F", "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=f2f"}]'


### PR DESCRIPTION
## Proposed changes

### What changed

Adds GOVUKNOTIFYREMINDERTEMPLATEID env var to integration env

### Why did it change

Because it was missing and breaking the integration pipeline

### Issue tracking
- [F2F-1275](https://govukverify.atlassian.net/browse/F2F-1275)
