### PR TITLE
[KIWI-1227] - Send Dynamic Reminder Emails

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,6 +104,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://f2f-gov-notify-stub-govnotifystub.review-o.dev.account.gov.uk/govnotify"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/redirect?id=f2f"}]'
@@ -120,6 +121,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://govnotifystub.review-o.build.account.gov.uk/govnotify"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-o.build.account.gov.uk/.well-known/jwks.json","clientId":"BD7B2A5D","redirectUri":"https://ipvstub.review-o.build.account.gov.uk/redirect?id=f2f"}]'
@@ -136,6 +138,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.staging.account.gov.uk/.well-known/jwks.json","clientId":"03A5A659-17AA-453F-B905-95D2804823D1","redirectUri":"https://identity.staging.account.gov.uk/credential-issuer/callback?id=f2f"}]'
@@ -151,6 +154,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json", "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F", "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=f2f"}]'
@@ -166,6 +170,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "ccba5634-33e9-4e0d-96c1-57067db941af"
       GOVUKNOTIFYREMINDERTEMPLATEID: "0d0d2aab-3c31-46da-8462-1af0f5f456f0"
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.account.gov.uk/.well-known/jwks.json", "clientId":"C910A762-4BB2-400D-8F3D-4D7E6C84E342", "redirectUri":"https://identity.account.gov.uk/credential-issuer/callback?id=f2f"}]'
@@ -1696,6 +1701,7 @@ Resources:
           GOVUKNOTIFY_API: !FindInMap [ EnvironmentVariables, !Ref Environment, GOVUKNOTIFYAPI ]
           GOVUKNOTIFY_PDF_TEMPLATE_ID: !FindInMap [ EnvironmentVariables, !Ref Environment, GOVUKNOTIFYPDFTEMPLATEID ]
           GOVUKNOTIFY_REMINDER_TEMPLATE_ID: !FindInMap [ EnvironmentVariables, !Ref Environment, GOVUKNOTIFYREMINDERTEMPLATEID ]
+          GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID: !FindInMap [ EnvironmentVariables, !Ref Environment, GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID ]
           YOTI_KEY_SSM_PATH: !Sub "/${Environment}/YOTI/PRIVATEKEY"
           GOVUKNOTIFY_API_KEY_SSM_PATH: !Sub "/${Environment}/f2f-gov-notify/GOVUKNOTIFY_API_KEY"
           YOTIBASEURL: !FindInMap [ EnvironmentVariables, !Ref Environment, YOTIBASEURL ]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://f2f-gov-notify-stub-govnotifystub.review-o.dev.account.gov.uk/govnotify"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
-      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: "0261960b-9126-4aac-88f3-0026287c0423"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://f2f-ipv-stub-ipvstub.review-o.dev.account.gov.uk/redirect?id=f2f"}]'
@@ -121,7 +121,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://govnotifystub.review-o.build.account.gov.uk/govnotify"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
-      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: "0261960b-9126-4aac-88f3-0026287c0423"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-o.build.account.gov.uk/.well-known/jwks.json","clientId":"BD7B2A5D","redirectUri":"https://ipvstub.review-o.build.account.gov.uk/redirect?id=f2f"}]'
@@ -138,7 +138,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
-      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: "0261960b-9126-4aac-88f3-0026287c0423"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.staging.account.gov.uk/.well-known/jwks.json","clientId":"03A5A659-17AA-453F-B905-95D2804823D1","redirectUri":"https://identity.staging.account.gov.uk/credential-issuer/callback?id=f2f"}]'
@@ -154,7 +154,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "bea2a584-4dca-4970-a90d-93977e752fdf"
       GOVUKNOTIFYREMINDERTEMPLATEID: "2987ded5-1c1b-4336-931b-7f66a5569684"
-      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: "0261960b-9126-4aac-88f3-0026287c0423"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json", "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F", "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=f2f"}]'
@@ -170,7 +170,7 @@ Mappings:
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       GOVUKNOTIFYPDFTEMPLATEID: "ccba5634-33e9-4e0d-96c1-57067db941af"
       GOVUKNOTIFYREMINDERTEMPLATEID: "0d0d2aab-3c31-46da-8462-1af0f5f456f0"
-      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: ""
+      GOVUKNOTIFYDYNAMICREMINDERTEMPLATEID: "0d3b9cb6-2c54-4316-865a-933f0f0dfb53"
       YOTISESSIONTTLDAYS: 10 # Default 10 days
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.account.gov.uk/.well-known/jwks.json", "clientId":"C910A762-4BB2-400D-8F3D-4D7E6C84E342", "redirectUri":"https://identity.account.gov.uk/credential-issuer/callback?id=f2f"}]'

--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -115,6 +115,7 @@ Resources:
               - "createdDate"
               - "reminderEmailSent"
               - "expiryDate"
+              - "documentUsed"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiryDate

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -8,6 +8,7 @@ process.env.AUTH_SESSION_TTL_SECS = '950400'
 process.env.REGION = 'eu-west-2'
 process.env.GOVUKNOTIFY_PDF_TEMPLATE_ID = "bea2a584-4dca-4970-a90d-93977e752fdf"
 process.env.GOVUKNOTIFY_REMINDER_TEMPLATE_ID = "1490de9b-d986-4404-b260-ece7f1837115"
+process.env.GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID = "1490de9b-d986-4404-b260-ece7f1837116"
 process.env.YOTISDK = "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
 process.env.YOTIBASEURL = "https://XXX-proxy.review-o.dev.account.gov.uk/yoti"
 process.env.YOTI_KEY_SSM_PATH = "/dev/YOTI/PRIVATEKEY"

--- a/src/models/DynamicReminderEmail.ts
+++ b/src/models/DynamicReminderEmail.ts
@@ -1,0 +1,52 @@
+import { IsString, IsNotEmpty, IsOptional, IsEmail } from "class-validator";
+import { randomUUID } from "crypto";
+
+import { AppError } from "../utils/AppError";
+import { HttpCodesEnum } from "./enums/HttpCodesEnum";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+/**
+ * Object to represent data contained in email messages sent by this lambda
+ */
+export class DynamicReminderEmail {
+
+	constructor(data: Partial<DynamicReminderEmail>) {
+		this.emailAddress = data.emailAddress!;
+		this.firstName = data.firstName!;
+		this.lastName = data.lastName!
+		this.docType = data.docType!;
+		this.referenceId = randomUUID();
+	}
+
+	static parseRequest(data: any, logger: Logger): DynamicReminderEmail {
+		try {
+			return new DynamicReminderEmail(JSON.parse(data));
+		} catch (error: any) {
+			logger.error("Cannot parse ReminderEmail data");
+			throw new AppError( HttpCodesEnum.BAD_REQUEST, "Cannot parse ReminderEmail data");
+		}
+	}
+
+	@IsString()
+	@IsNotEmpty()
+	@IsEmail()
+	emailAddress!: string;
+
+	@IsString()
+    @IsNotEmpty()
+    firstName!: string;
+
+	@IsString()
+	@IsNotEmpty()
+	lastName!: string;
+
+	@IsString()
+	@IsNotEmpty()
+	docType!: string;
+
+
+	@IsString()
+	@IsNotEmpty()
+	referenceId!: string;
+
+}

--- a/src/models/DynamicReminderEmail.ts
+++ b/src/models/DynamicReminderEmail.ts
@@ -14,7 +14,7 @@ export class DynamicReminderEmail {
 		this.emailAddress = data.emailAddress!;
 		this.firstName = data.firstName!;
 		this.lastName = data.lastName!;
-		this.docType = data.docType!;
+		this.documentUsed = data.documentUsed!;
 		this.referenceId = randomUUID();
 	}
 
@@ -42,7 +42,7 @@ export class DynamicReminderEmail {
 
 	@IsString()
 	@IsNotEmpty()
-	docType!: string;
+	documentUsed!: string;
 
 
 	@IsString()

--- a/src/models/DynamicReminderEmail.ts
+++ b/src/models/DynamicReminderEmail.ts
@@ -13,7 +13,7 @@ export class DynamicReminderEmail {
 	constructor(data: Partial<DynamicReminderEmail>) {
 		this.emailAddress = data.emailAddress!;
 		this.firstName = data.firstName!;
-		this.lastName = data.lastName!
+		this.lastName = data.lastName!;
 		this.docType = data.docType!;
 		this.referenceId = randomUUID();
 	}

--- a/src/models/enums/DocumentTypes.ts
+++ b/src/models/enums/DocumentTypes.ts
@@ -12,6 +12,20 @@ export enum DocumentNames {
 	NATIONAL_ID = "idCard",
 }
 
+export enum EmailDocumentNamesEnglish {
+	PASSPORT = "Passport",
+	RESIDENCE_PERMIT = "Residence Permit",
+	DRIVING_LICENCE = "Driving Licence",
+	NATIONAL_ID = "National ID",
+}
+
+export enum EmailDocumentNamesWelsh {
+	PASSPORT = "Passport",
+	RESIDENCE_PERMIT = "Residence Permit",
+	DRIVING_LICENCE = "Driving Licence",
+	NATIONAL_ID = "National ID",
+}
+
 export enum AllDocumentTypes {
 	UK_PASSPORT = "ukPassport",
 	NON_UK_PASSPORT = "nonUkPassport",

--- a/src/models/enums/DocumentTypes.ts
+++ b/src/models/enums/DocumentTypes.ts
@@ -12,20 +12,6 @@ export enum DocumentNames {
 	NATIONAL_ID = "idCard",
 }
 
-export enum EmailDocumentNamesEnglish {
-	PASSPORT = "Passport",
-	RESIDENCE_PERMIT = "Residence Permit",
-	DRIVING_LICENCE = "Driving Licence",
-	NATIONAL_ID = "National ID",
-}
-
-export enum EmailDocumentNamesWelsh {
-	PASSPORT = "Passport",
-	RESIDENCE_PERMIT = "Residence Permit",
-	DRIVING_LICENCE = "Driving Licence",
-	NATIONAL_ID = "National ID",
-}
-
 export enum AllDocumentTypes {
 	UK_PASSPORT = "ukPassport",
 	NON_UK_PASSPORT = "nonUkPassport",

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -168,9 +168,9 @@ export class DocumentSelectionRequestProcessor {
   				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unknown document type");
   		}
 
-			try {
-  			this.logger.info("Updating documentType in Session Table: ", {docType});
-				await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
+  		try {
+  			this.logger.info("Updating documentType in Session Table: ", { docType });
+  			await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
   		} catch (error: any) {
   			this.logger.error("Error occurred during documentSelection orchestration", error.message,
   				{ messageCode: MessageCodes.FAILED_DOCUMENT_SELECTION_ORCHESTRATION });

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -168,8 +168,18 @@ export class DocumentSelectionRequestProcessor {
   				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unknown document type");
   		}
 
-			this.logger.info("Updating documentType in Session Table: ", {docType});
-			await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
+			try {
+  			this.logger.info("Updating documentType in Session Table: ", {docType});
+				await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
+  		} catch (error: any) {
+  			this.logger.error("Error occurred during documentSelection orchestration", error.message,
+  				{ messageCode: MessageCodes.FAILED_DOCUMENT_SELECTION_ORCHESTRATION });
+  			if (error instanceof AppError) {
+  				return new Response(HttpCodesEnum.SERVER_ERROR, error.message);
+  			} else {
+  				return new Response(HttpCodesEnum.SERVER_ERROR, "An error has occurred");
+  			}
+  		}
 
   		try {
   			const coreEventFields = buildCoreEventFields(f2fSessionInfo, this.environmentVariables.issuer(), f2fSessionInfo.clientIpAddress, absoluteTimeNow);

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -167,7 +167,7 @@ export class DocumentSelectionRequestProcessor {
   		}
 
   		try {
-  			this.logger.info("Updating selected document in Session Table: ", { docType });
+  			this.logger.info("Updating documentUsed in Session Table: ", { documentUsed: docType });
   			await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
   		} catch (error: any) {
   			this.logger.error("Error occurred during documentSelection orchestration", error.message,

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -168,6 +168,9 @@ export class DocumentSelectionRequestProcessor {
   				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unknown document type");
   		}
 
+			this.logger.info("Updating documentType in Session Table: ", {docType});
+			await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
+
   		try {
   			const coreEventFields = buildCoreEventFields(f2fSessionInfo, this.environmentVariables.issuer(), f2fSessionInfo.clientIpAddress, absoluteTimeNow);
   			await this.f2fService.sendToTXMA({

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -18,9 +18,7 @@ import { PersonIdentityItem } from "../models/PersonIdentityItem";
 import { PostOfficeInfo } from "../models/YotiPayloads";
 import { MessageCodes } from "../models/enums/MessageCodes";
 import { AllDocumentTypes, DocumentNames, DocumentTypes } from "../models/enums/DocumentTypes";
-import { DrivingPermit, IdentityCard, Passport, ResidencePermit } from "../utils/IVeriCredential";
 import { ValidationHelper } from "../utils/ValidationHelper";
-import { personIdentityUtils } from "../utils/PersonIdentityUtils";
 
 export class DocumentSelectionRequestProcessor {
 
@@ -169,7 +167,7 @@ export class DocumentSelectionRequestProcessor {
   		}
 
   		try {
-  			this.logger.info("Updating documentType in Session Table: ", { docType });
+  			this.logger.info("Updating selected document in Session Table: ", { docType });
   			await this.f2fService.addUsersSelectedDocument(f2fSessionInfo.sessionId, docType, this.environmentVariables.sessionTable());
   		} catch (error: any) {
   			this.logger.error("Error occurred during documentSelection orchestration", error.message,

--- a/src/services/EnvironmentVariables.ts
+++ b/src/services/EnvironmentVariables.ts
@@ -16,6 +16,8 @@ export class EnvironmentVariables {
 
 	private readonly GOVUKNOTIFY_REMINDER_TEMPLATE_ID = process.env.GOVUKNOTIFY_REMINDER_TEMPLATE_ID;
 
+	private readonly GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID = process.env.GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID;
+
 	private GOVUKNOTIFY_MAX_RETRIES = process.env.GOVUKNOTIFY_MAX_RETRIES;
 
 	private GOVUKNOTIFY_BACKOFF_PERIOD_MS = process.env.GOVUKNOTIFY_BACKOFF_PERIOD_MS;
@@ -290,6 +292,14 @@ export class EnvironmentVariables {
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
 		}
 		return this.GOVUKNOTIFY_REMINDER_TEMPLATE_ID;
+	}
+
+	getDynamicReminderEmailTemplateId(logger: Logger): any {
+		if (!this.GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID || this.GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID.trim().length === 0) {
+			logger.error(`GovNotifyService - Misconfigured external API's key ${EnvironmentVariables.name}`);
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+		}
+		return this.GOVUKNOTIFY_DYNAMIC_REMINDER_TEMPLATE_ID;
 	}
 
 	maxRetries(): number {

--- a/src/services/F2fService.ts
+++ b/src/services/F2fService.ts
@@ -459,12 +459,12 @@ export class F2fService {
 			},
 		});
 
-		this.logger.info({ message: `Updating selected document in ${tableName}`, updateStateCommand });
+		this.logger.info({ message: `Updating documentUsed in ${tableName}`, updateStateCommand });
 		try {
 			await this.dynamo.send(updateStateCommand);
-			this.logger.info({ message: `Updated ${tableName} with selected document` });
+			this.logger.info({ message: `Updated ${tableName} with documentUsed` });
 		} catch (error) {
-			this.logger.error({ message: `Got error updating selected document in ${tableName}`, error });
+			this.logger.error({ message: `Got error updating documentUsed in ${tableName}`, error });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, `updateItem - failed: got error updating ${tableName}`);
 		}
 	}

--- a/src/services/F2fService.ts
+++ b/src/services/F2fService.ts
@@ -449,4 +449,24 @@ export class F2fService {
 		}
 	}
 
+	async addUsersSelectedDocument(sessionId: string, documentUsed: string, tableName: string = this.tableName): Promise<void> {
+		const updateStateCommand = new UpdateCommand({
+			TableName: tableName,
+			Key: { sessionId },
+			UpdateExpression: "SET documentUsed = :documentUsed",
+			ExpressionAttributeValues: {
+				":documentUsed": documentUsed,
+			},
+		});
+
+		this.logger.info({ message: `Updating ${tableName} table TTL`, updateStateCommand });
+		try {
+			await this.dynamo.send(updateStateCommand);
+			this.logger.info({ message: `Updated ${tableName} TTL in dynamodb` });
+		} catch (error) {
+			this.logger.error({ message: `Got error updating ${tableName} ttl`, error });
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, `updateItem - failed: got error updating ${tableName} ttl`);
+		}
+	}
+
 }

--- a/src/services/F2fService.ts
+++ b/src/services/F2fService.ts
@@ -459,13 +459,13 @@ export class F2fService {
 			},
 		});
 
-		this.logger.info({ message: `Updating ${tableName} table TTL`, updateStateCommand });
+		this.logger.info({ message: `Updating selected document in ${tableName}`, updateStateCommand });
 		try {
 			await this.dynamo.send(updateStateCommand);
-			this.logger.info({ message: `Updated ${tableName} TTL in dynamodb` });
+			this.logger.info({ message: `Updated ${tableName} with selected document` });
 		} catch (error) {
-			this.logger.error({ message: `Got error updating ${tableName} ttl`, error });
-			throw new AppError(HttpCodesEnum.SERVER_ERROR, `updateItem - failed: got error updating ${tableName} ttl`);
+			this.logger.error({ message: `Got error updating selected document in ${tableName}`, error });
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, `updateItem - failed: got error updating ${tableName}`);
 		}
 	}
 

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -30,6 +30,8 @@ export class ReminderEmailProcessor {
   	try {
   		const F2FSessionCreatedRecords = await this.f2fService.getSessionsByAuthSessionStates([AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]);
 
+			// console.log('F2FSessionCreatedRecords', F2FSessionCreatedRecords);
+
   		if (F2FSessionCreatedRecords.length === 0) {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]}`);
   			return { statusCode: HttpCodesEnum.OK, body: "No Session Records matching state" };
@@ -44,6 +46,8 @@ export class ReminderEmailProcessor {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]} older than 5 days`);
   			return { statusCode: HttpCodesEnum.OK, body: "No Sessions older than 5 days" };
   		}
+
+			// console.log('filteredSessions', filteredSessions);
 
   		this.logger.info("Total num. of users to send reminder emails to:", { numOfUsers: filteredSessions.length });
 

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -30,8 +30,6 @@ export class ReminderEmailProcessor {
   	try {
   		const F2FSessionCreatedRecords = await this.f2fService.getSessionsByAuthSessionStates([AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]);
 
-  		// console.log('F2FSessionCreatedRecords', F2FSessionCreatedRecords);
-
   		if (F2FSessionCreatedRecords.length === 0) {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]}`);
   			return { statusCode: HttpCodesEnum.OK, body: "No Session Records matching state" };
@@ -46,8 +44,6 @@ export class ReminderEmailProcessor {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]} older than 5 days`);
   			return { statusCode: HttpCodesEnum.OK, body: "No Sessions older than 5 days" };
   		}
-
-  		// console.log('filteredSessions', filteredSessions);
 
   		this.logger.info("Total num. of users to send reminder emails to:", { numOfUsers: filteredSessions.length });
 

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -8,8 +8,9 @@ import { EnvironmentVariables } from "./EnvironmentVariables";
 import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { MessageCodes } from "../models/enums/MessageCodes";
 import { AuthSessionState } from "../models/enums/AuthSessionState";
-import { buildReminderEmailEventFields } from "../utils/GovNotifyEvent";
+import { buildDynamicReminderEmailEventFields, buildReminderEmailEventFields } from "../utils/GovNotifyEvent";
 import { absoluteTimeNow } from "../utils/DateTimeUtils";
+import { personIdentityUtils } from "../utils/PersonIdentityUtils";
 
 export class ReminderEmailProcessor {
   private static instance: ReminderEmailProcessor;
@@ -47,12 +48,13 @@ export class ReminderEmailProcessor {
   		this.logger.info("Total num. of users to send reminder emails to:", { numOfUsers: filteredSessions.length });
 
   		const usersToRemind = await Promise.all(
-  			filteredSessions.map(async ({ sessionId }) => {
+  			filteredSessions.map(async ({ sessionId, documentUsed }) => {
   				try {
   					const envVariables = new EnvironmentVariables(this.logger, ServicesEnum.REMINDER_SERVICE);
   					const personIdentityItem = await this.f2fService.getPersonIdentityById(sessionId, envVariables.personIdentityTableName());
   					if ( personIdentityItem ) {
-  						return { sessionId, emailAddress: personIdentityItem.emailAddress };
+							const nameParts = personIdentityUtils.getNames(personIdentityItem);
+  						return { sessionId, emailAddress: personIdentityItem.emailAddress, firstName: nameParts.givenNames[0], lastName: nameParts.familyNames[0], documentUsed  };
   					} else {
   						this.logger.warn("No records returned from Person Identity Table");
   						return null;
@@ -68,10 +70,16 @@ export class ReminderEmailProcessor {
   		}
 
   		const sendEmailPromises = usersToRemind
-  			.filter((user): user is { sessionId: any; emailAddress: string } => user !== null)
-  			.map(async ({ sessionId, emailAddress }) => {
+  			.filter((user): user is { sessionId: any; emailAddress: string, firstName: string, lastName: string, documentUsed: string } => user !== null)
+  			.map(async ({ sessionId, emailAddress, firstName, lastName, documentUsed  }) => {
   				try {
-  					await this.f2fService.sendToGovNotify(buildReminderEmailEventFields(emailAddress));
+						if (firstName && lastName && documentUsed) {
+							this.logger.info("Sending Dynamic Reminder Email", { sessionId })
+							await this.f2fService.sendToGovNotify(buildDynamicReminderEmailEventFields(emailAddress, firstName, lastName, documentUsed));
+						} else { 
+							this.logger.info("Sending Static Reminder Email", { sessionId })
+							await this.f2fService.sendToGovNotify(buildReminderEmailEventFields(emailAddress));
+						}
   					await this.f2fService.updateReminderEmailFlag(sessionId, true);
   					this.logger.info("Reminder email sent to user: ", { sessionId });
   				} catch (error) {

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -30,7 +30,7 @@ export class ReminderEmailProcessor {
   	try {
   		const F2FSessionCreatedRecords = await this.f2fService.getSessionsByAuthSessionStates([AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]);
 
-			// console.log('F2FSessionCreatedRecords', F2FSessionCreatedRecords);
+  		// console.log('F2FSessionCreatedRecords', F2FSessionCreatedRecords);
 
   		if (F2FSessionCreatedRecords.length === 0) {
   			this.logger.info(`No users with session states ${[AuthSessionState.F2F_YOTI_SESSION_CREATED, AuthSessionState.F2F_AUTH_CODE_ISSUED, AuthSessionState.F2F_ACCESS_TOKEN_ISSUED]}`);
@@ -47,7 +47,7 @@ export class ReminderEmailProcessor {
   			return { statusCode: HttpCodesEnum.OK, body: "No Sessions older than 5 days" };
   		}
 
-			// console.log('filteredSessions', filteredSessions);
+  		// console.log('filteredSessions', filteredSessions);
 
   		this.logger.info("Total num. of users to send reminder emails to:", { numOfUsers: filteredSessions.length });
 
@@ -57,8 +57,8 @@ export class ReminderEmailProcessor {
   					const envVariables = new EnvironmentVariables(this.logger, ServicesEnum.REMINDER_SERVICE);
   					const personIdentityItem = await this.f2fService.getPersonIdentityById(sessionId, envVariables.personIdentityTableName());
   					if ( personIdentityItem ) {
-							const nameParts = personIdentityUtils.getNames(personIdentityItem);
-  						return { sessionId, emailAddress: personIdentityItem.emailAddress, firstName: nameParts.givenNames[0], lastName: nameParts.familyNames[0], documentUsed  };
+  						const nameParts = personIdentityUtils.getNames(personIdentityItem);
+  						return { sessionId, emailAddress: personIdentityItem.emailAddress, firstName: nameParts.givenNames[0], lastName: nameParts.familyNames[0], documentUsed };
   					} else {
   						this.logger.warn("No records returned from Person Identity Table");
   						return null;
@@ -74,16 +74,16 @@ export class ReminderEmailProcessor {
   		}
 
   		const sendEmailPromises = usersToRemind
-  			.filter((user): user is { sessionId: any; emailAddress: string, firstName: string, lastName: string, documentUsed: string } => user !== null)
-  			.map(async ({ sessionId, emailAddress, firstName, lastName, documentUsed  }) => {
+  			.filter((user): user is { sessionId: any; emailAddress: string; firstName: string; lastName: string; documentUsed: string } => user !== null)
+  			.map(async ({ sessionId, emailAddress, firstName, lastName, documentUsed }) => {
   				try {
-						if (firstName && lastName && documentUsed) {
-							this.logger.info("Sending Dynamic Reminder Email", { sessionId })
-							await this.f2fService.sendToGovNotify(buildDynamicReminderEmailEventFields(emailAddress, firstName, lastName, documentUsed));
-						} else { 
-							this.logger.info("Sending Static Reminder Email", { sessionId })
-							await this.f2fService.sendToGovNotify(buildReminderEmailEventFields(emailAddress));
-						}
+  					if (firstName && lastName && documentUsed) {
+  						this.logger.info("Sending Dynamic Reminder Email", { sessionId });
+  						await this.f2fService.sendToGovNotify(buildDynamicReminderEmailEventFields(emailAddress, firstName, lastName, documentUsed));
+  					} else { 
+  						this.logger.info("Sending Static Reminder Email", { sessionId });
+  						await this.f2fService.sendToGovNotify(buildReminderEmailEventFields(emailAddress));
+  					}
   					await this.f2fService.updateReminderEmailFlag(sessionId, true);
   					this.logger.info("Reminder email sent to user: ", { sessionId });
   				} catch (error) {

--- a/src/services/SendEmailProcessor.ts
+++ b/src/services/SendEmailProcessor.ts
@@ -4,6 +4,7 @@ import { SendEmailService } from "./SendEmailService";
 import { Constants } from "../utils/Constants";
 import { Email } from "../models/Email";
 import { ReminderEmail } from "../models/ReminderEmail";
+import { DynamicReminderEmail } from "../models/DynamicReminderEmail";
 import { EmailResponse } from "../models/EmailResponse";
 import { ValidationHelper } from "../utils/ValidationHelper";
 
@@ -27,6 +28,11 @@ export class SendEmailProcessor {
   	const messageType = eventBody.Message.messageType;
 
   	switch (messageType) {
+			case Constants.REMINDER_EMAIL_DYNAMIC:
+  			const dynamicReminderEmail = DynamicReminderEmail.parseRequest(JSON.stringify(eventBody.Message), this.logger);
+  			await this.validationHelper.validateModel(dynamicReminderEmail, this.logger);
+  			return this.govNotifyService.sendDynamicReminderEmail(dynamicReminderEmail);
+				
   		case Constants.REMINDER_EMAIL:
   			const reminderEmail = ReminderEmail.parseRequest(JSON.stringify(eventBody.Message), this.logger);
   			await this.validationHelper.validateModel(reminderEmail, this.logger);

--- a/src/services/SendEmailProcessor.ts
+++ b/src/services/SendEmailProcessor.ts
@@ -28,7 +28,7 @@ export class SendEmailProcessor {
   	const messageType = eventBody.Message.messageType;
 
   	switch (messageType) {
-			case Constants.REMINDER_EMAIL_DYNAMIC:
+  		case Constants.REMINDER_EMAIL_DYNAMIC:
   			const dynamicReminderEmail = DynamicReminderEmail.parseRequest(JSON.stringify(eventBody.Message), this.logger);
   			await this.validationHelper.validateModel(dynamicReminderEmail, this.logger);
   			return this.govNotifyService.sendDynamicReminderEmail(dynamicReminderEmail);

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -132,7 +132,7 @@ export class SendEmailService {
 				personalisation: {
 					[GOV_NOTIFY_OPTIONS.FIRST_NAME]: message.firstName,
 					[GOV_NOTIFY_OPTIONS.LAST_NAME]: message.lastName,
-					[GOV_NOTIFY_OPTIONS.CHOSEN_PHOTO_ID]: message.docType,
+					[GOV_NOTIFY_OPTIONS.CHOSEN_PHOTO_ID]: message.documentUsed,
 				},
 				reference: message.referenceId,
 			};

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -120,6 +120,7 @@ export class SendEmailService {
 	}
 
 	async sendDynamicReminderEmail(message: DynamicReminderEmail): Promise<EmailResponse> {
+		console.log('message', message);
 		this.logger.info("Sending reminder email");
 
 		try {
@@ -131,8 +132,12 @@ export class SendEmailService {
 				},
 				reference: message.referenceId,
 			};
+
+			console.log('options', options);
 		
+			console.log('key', this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger));
 			const emailResponse = await this.sendGovNotification(this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger), message, options);
+			console.log('emailResponse', emailResponse);
 			return emailResponse;
 		} catch (err: any) {
 			this.logger.error("Failed to send Dynamic Reminder Email", { messageCode: MessageCodes.FAILED_TO_SEND_REMINDER_EMAIL });

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -18,6 +18,7 @@ import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { ReminderEmail } from "../models/ReminderEmail";
 import { DynamicReminderEmail } from "../models/DynamicReminderEmail";
 import { MessageCodes } from "../models/enums/MessageCodes";
+import { Constants } from "../utils/Constants";
 
 
 /**
@@ -81,11 +82,13 @@ export class SendEmailService {
 				this.logger.debug("sendEmail", SendEmailService.name);
 				this.logger.info("Sending Yoti PDF email");
 
+				const { GOV_NOTIFY_OPTIONS } = Constants;
+
 				const options = {
 					personalisation: {
-						"first name": message.firstName,
-						"last name": message.lastName,
-						"link_to_file": { "file": encoded, "confirm_email_before_download": true, "retention_period": "2 weeks" },
+						[GOV_NOTIFY_OPTIONS.FIRST_NAME]: message.firstName,
+						[GOV_NOTIFY_OPTIONS.LAST_NAME]: message.lastName,
+						[GOV_NOTIFY_OPTIONS.LINK_TO_FILE]: { "file": encoded, "confirm_email_before_download": true, "retention_period": "2 weeks" },
 					},
 					reference: message.referenceId,
 				};
@@ -120,14 +123,16 @@ export class SendEmailService {
 	}
 
 	async sendDynamicReminderEmail(message: DynamicReminderEmail): Promise<EmailResponse> {
-		this.logger.info("Sending reminder email");
+		this.logger.info("Sending dynamic reminder email");
+
+		const { GOV_NOTIFY_OPTIONS } = Constants;
 
 		try {
 			const options = {
 				personalisation: {
-					"first name": message.firstName,
-					"last name": message.lastName,
-					"chosen photo ID": message.docType,
+					[GOV_NOTIFY_OPTIONS.FIRST_NAME]: message.firstName,
+					[GOV_NOTIFY_OPTIONS.LAST_NAME]: message.lastName,
+					[GOV_NOTIFY_OPTIONS.CHOSEN_PHOTO_ID]: message.docType,
 				},
 				reference: message.referenceId,
 			};

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -120,7 +120,7 @@ export class SendEmailService {
 	}
 
 	async sendDynamicReminderEmail(message: DynamicReminderEmail): Promise<EmailResponse> {
-		console.log('message', message);
+		console.log("message", message);
 		this.logger.info("Sending reminder email");
 
 		try {
@@ -128,16 +128,16 @@ export class SendEmailService {
 				personalisation: {
 					"first name": message.firstName,
 					"last name": message.lastName,
-					"chosen photo ID": message.docType
+					"chosen photo ID": message.docType,
 				},
 				reference: message.referenceId,
 			};
 
-			console.log('options', options);
+			console.log("options", options);
 		
-			console.log('key', this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger));
+			console.log("key", this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger));
 			const emailResponse = await this.sendGovNotification(this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger), message, options);
-			console.log('emailResponse', emailResponse);
+			console.log("emailResponse", emailResponse);
 			return emailResponse;
 		} catch (err: any) {
 			this.logger.error("Failed to send Dynamic Reminder Email", { messageCode: MessageCodes.FAILED_TO_SEND_REMINDER_EMAIL });

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -120,7 +120,6 @@ export class SendEmailService {
 	}
 
 	async sendDynamicReminderEmail(message: DynamicReminderEmail): Promise<EmailResponse> {
-		console.log("message", message);
 		this.logger.info("Sending reminder email");
 
 		try {
@@ -133,11 +132,7 @@ export class SendEmailService {
 				reference: message.referenceId,
 			};
 
-			console.log("options", options);
-		
-			console.log("key", this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger));
 			const emailResponse = await this.sendGovNotification(this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger), message, options);
-			console.log("emailResponse", emailResponse);
 			return emailResponse;
 		} catch (err: any) {
 			this.logger.error("Failed to send Dynamic Reminder Email", { messageCode: MessageCodes.FAILED_TO_SEND_REMINDER_EMAIL });

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -16,6 +16,7 @@ import { F2fService } from "./F2fService";
 import { createDynamoDbClient } from "../utils/DynamoDBFactory";
 import { ServicesEnum } from "../models/enums/ServicesEnum";
 import { ReminderEmail } from "../models/ReminderEmail";
+import { DynamicReminderEmail } from "../models/DynamicReminderEmail";
 import { MessageCodes } from "../models/enums/MessageCodes";
 
 
@@ -115,6 +116,27 @@ export class SendEmailService {
 		} catch (err: any) {
 			this.logger.error("Failed to send Reminder Email", { messageCode: MessageCodes.FAILED_TO_SEND_REMINDER_EMAIL });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "sendReminderEmail - Failed sending Reminder Email");
+		}
+	}
+
+	async sendDynamicReminderEmail(message: DynamicReminderEmail): Promise<EmailResponse> {
+		this.logger.info("Sending reminder email");
+
+		try {
+			const options = {
+				personalisation: {
+					"first name": message.firstName,
+					"last name": message.lastName,
+					"chosen photo ID": message.docType
+				},
+				reference: message.referenceId,
+			};
+		
+			const emailResponse = await this.sendGovNotification(this.environmentVariables.getDynamicReminderEmailTemplateId(this.logger), message, options);
+			return emailResponse;
+		} catch (err: any) {
+			this.logger.error("Failed to send Dynamic Reminder Email", { messageCode: MessageCodes.FAILED_TO_SEND_REMINDER_EMAIL });
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, "sendReminderEmail - Failed sending Dynamic Reminder Email");
 		}
 	}
 

--- a/src/tests/unit/data/sqs-events.ts
+++ b/src/tests/unit/data/sqs-events.ts
@@ -27,7 +27,7 @@ export const VALID_DYNAMIC_REMINDER_SQS_EVENT = {
 			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
 			// pragma: allowlist nextline secret
 			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-			"body": "{\"Message\":{\"docType\":\"PASSPORT\",\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"REMINDER_EMAIL_DYNAMIC\"}}",
+			"body": "{\"Message\":{\"documentUsed\":\"PASSPORT\",\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"REMINDER_EMAIL_DYNAMIC\"}}",
 			"attributes": {
 				"ApproximateReceiveCount": "1",
 				"SentTimestamp": "1588867971441",

--- a/src/tests/unit/data/sqs-events.ts
+++ b/src/tests/unit/data/sqs-events.ts
@@ -4,7 +4,55 @@ export const VALID_SQS_EVENT = {
 			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
 			// pragma: allowlist nextline secret
 			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
-			"body": "{\"Message\":{\"sessionId\":\"eb26c8e0-397b-4f5e-b7a5-62cd0c6e510b\",\"yotiSessionId\":\"8fbbe7bf-3ce6-4dc0-b4f3-b36d4684c6bc\",\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"PDF_EMAIL\"}}",
+			"body": "{\"Message\":{\"sessionId\":\"eb26c8e0-397b-4f5e-b7a5-62cd0c6e510b\",\"yotiSessionId\":\"8fbbe7bf-3ce6-4dc0-b4f3-b36d4684c6bc\",\"emailAddress\":\"example@test.com\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"PDF_EMAIL\"}}",
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
+};
+
+export const VALID_DYNAMIC_REMINDER_SQS_EVENT = {
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": "{\"Message\":{\"docType\":\"PASSPORT\",\"emailAddress\":\"bhavana.hemanth@digital.cabinet-office.gov.uk\",\"firstName\":\"Frederick\",\"lastName\":\"Flintstone\",\"messageType\":\"REMINDER_EMAIL_DYNAMIC\"}}",
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
+};
+
+
+
+export const VALID_REMINDER_SQS_EVENT = {
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": "{\"Message\":{\"emailAddress\":\"example@test.com\",\"messageType\":\"REMINDER_EMAIL\"}}",
 			"attributes": {
 				"ApproximateReceiveCount": "1",
 				"SentTimestamp": "1588867971441",

--- a/src/tests/unit/data/sqs-events.ts
+++ b/src/tests/unit/data/sqs-events.ts
@@ -45,7 +45,6 @@ export const VALID_DYNAMIC_REMINDER_SQS_EVENT = {
 };
 
 
-
 export const VALID_REMINDER_SQS_EVENT = {
 	"Records": [
 		{

--- a/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
+++ b/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
@@ -315,7 +315,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.updateSessionTtl).toHaveBeenNthCalledWith(2, "RandomF2FSessionID", Math.floor(fakeTime + +process.env.AUTH_SESSION_TTL_SECS!), "PERSONIDENTITYTABLE");
 	});
 
-	it("Should save the selected document type in session table", async () => {
+	it("Should save the documentUsed type in session table", async () => {
 		mockF2fService.getSessionById.mockResolvedValueOnce(f2fSessionItem);
 		mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
 
@@ -606,7 +606,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(out.body).toBe("An error has occurred");
 	});
 
-	it("Return 500 when add users selected document returns an error", async () => {
+	it("Return 500 when add users documentUsed returns an error", async () => {
 		mockF2fService.getSessionById.mockResolvedValueOnce(f2fSessionItem);
 		mockF2fService.getPersonIdentityById.mockResolvedValueOnce(personIdentityItem);
 

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -441,7 +441,7 @@ describe("F2f Service", () => {
 		mockDynamoDbClient.send = jest.fn().mockRejectedValue({});
 		await expect(f2fService.addUsersSelectedDocument("SESSID", "passport", "SESSIONTABLE")).rejects.toThrow(expect.objectContaining({
 			statusCode: HttpCodesEnum.SERVER_ERROR,
-			message: `updateItem - failed: got error updating SESSIONTABLE`,
+			message: "updateItem - failed: got error updating SESSIONTABLE",
 		}));
 	});	
 });

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -419,7 +419,7 @@ describe("F2f Service", () => {
 		}));
 	});	
 
-	it("should update session table with selected document", async () => {
+	it("should update session table with documentUsed", async () => {
 		mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
 		await f2fService.addUsersSelectedDocument("SESSID", "passport", "SESSIONTABLE");
 		expect(mockDynamoDbClient.send).toHaveBeenCalledWith(expect.objectContaining({
@@ -437,7 +437,7 @@ describe("F2f Service", () => {
 	});
 	
 
-	it("should throw 500 if fails to update selected document", async () => {
+	it("should throw 500 if fails to update documentUsed", async () => {
 		mockDynamoDbClient.send = jest.fn().mockRejectedValue({});
 		await expect(f2fService.addUsersSelectedDocument("SESSID", "passport", "SESSIONTABLE")).rejects.toThrow(expect.objectContaining({
 			statusCode: HttpCodesEnum.SERVER_ERROR,

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -418,4 +418,30 @@ describe("F2f Service", () => {
 			message: `updateItem - failed: got error updating ${tableName} ttl`,
 		}));
 	});	
+
+	it("should update session table with selected document", async () => {
+		mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
+		await f2fService.addUsersSelectedDocument("SESSID", "passport", "SESSIONTABLE");
+		expect(mockDynamoDbClient.send).toHaveBeenCalledWith(expect.objectContaining({
+			input: {
+				ExpressionAttributeValues: {
+					":documentUsed": "passport",
+				},
+				Key: {
+					sessionId,
+				},
+				TableName: tableName,
+				UpdateExpression: "SET documentUsed = :documentUsed",
+			},
+		}));
+	});
+	
+
+	it("should throw 500 if fails to update selected document", async () => {
+		mockDynamoDbClient.send = jest.fn().mockRejectedValue({});
+		await expect(f2fService.addUsersSelectedDocument("SESSID", "passport", "SESSIONTABLE")).rejects.toThrow(expect.objectContaining({
+			statusCode: HttpCodesEnum.SERVER_ERROR,
+			message: `updateItem - failed: got error updating SESSIONTABLE`,
+		}));
+	});	
 });

--- a/src/tests/unit/services/ReminderEmailProcessor.test.ts
+++ b/src/tests/unit/services/ReminderEmailProcessor.test.ts
@@ -179,8 +179,8 @@ describe("ReminderEmailProcessor", () => {
 			expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
 			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
 			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
-			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(1, {"Message": {"docType": "NATIONAL_ID", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC"}});
-			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(2, {"Message": {"docType": "DRIVING_LICENCE", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC"}});
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(1, { "Message": { "docType": "NATIONAL_ID", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(2, { "Message": { "docType": "DRIVING_LICENCE", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
 			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
 			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
 		});

--- a/src/tests/unit/services/ReminderEmailProcessor.test.ts
+++ b/src/tests/unit/services/ReminderEmailProcessor.test.ts
@@ -45,6 +45,41 @@ describe("ReminderEmailProcessor", () => {
 		},
 	];
 
+	const F2FSessionsWithYotiSessionWithDocumentInfo = [
+		{
+			createdDate: 1686327580350,
+			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a4e",
+			reminderEmailSent: true,
+			authSessionState: "F2F_YOTI_SESSION_CREATED",
+			documentUsed: "PASSPORT",
+		},
+		{
+			createdDate: 1177408,
+			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a48",
+			authSessionState: "F2F_YOTI_SESSION_CREATED",
+			documentUsed: "NATIONAL_ID",
+		},
+		{
+			createdDate: 1695302248,
+			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a4h",
+			authSessionState: "F2F_YOTI_SESSION_CREATED",
+			documentUsed: "RESIDENCE_PERMIT",
+		},
+		{
+			createdDate: 1091008,
+			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a47",
+			reminderEmailSent: false,
+			authSessionState: "F2F_YOTI_SESSION_CREATED",
+			documentUsed: "DRIVING_LICENCE",
+		},
+		{
+			createdDate: 1695284750,
+			sessionId: "b2ba545c-18a9-4b7e-8bc1-38a05b214a43",
+			authSessionState: "F2F_YOTI_SESSION_CREATED",
+			documentUsed: "PASSPORT",
+		},
+	];
+
 	function getPersonIdentityItem(): PersonIdentityItem {
 		const personIdentityItem: PersonIdentityItem = {
 			"addresses": [
@@ -108,28 +143,47 @@ describe("ReminderEmailProcessor", () => {
 		jest.resetAllMocks();
 	});
 
-	it("should process request successfully", async () => {
-    
-		mockF2fService.getSessionsByAuthSessionStates.mockResolvedValue(F2FSessionsWithYotiSession);
-		mockF2fService.getPersonIdentityById.mockResolvedValue(personIdentityItem);
-		mockF2fService.sendToGovNotify.mockResolvedValue();
-		mockF2fService.updateReminderEmailFlag.mockResolvedValue();
-
-		const result = await reminderEmailProcessor.processRequest();
-
-		expect(result).toEqual({ statusCode: 200, body: "Success" });
-		expect(mockLogger.info).toHaveBeenCalledWith("Total num. of users to send reminder emails to:", { numOfUsers: 2 });
-		expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
-		expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
-		expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
-		expect(mockF2fService.sendToGovNotify).toHaveBeenCalledWith({
-			Message: {
-				emailAddress: "testReminder@test.com",
-				messageType: "REMINDER_EMAIL",
-			},
+	describe("Should process request successfully", () => {
+		beforeEach(() => {
+			mockF2fService.getSessionsByAuthSessionStates.mockResolvedValue(F2FSessionsWithYotiSession);
+			mockF2fService.getPersonIdentityById.mockResolvedValue(personIdentityItem);
+			mockF2fService.sendToGovNotify.mockResolvedValue();
+			mockF2fService.updateReminderEmailFlag.mockResolvedValue();
 		});
-		expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
-		expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
+	
+		it("when docType not present", async () => {
+			const result = await reminderEmailProcessor.processRequest();
+	
+			expect(result).toEqual({ statusCode: 200, body: "Success" });
+			expect(mockLogger.info).toHaveBeenCalledWith("Total num. of users to send reminder emails to:", { numOfUsers: 2 });
+			expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
+			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
+			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
+			expect(mockF2fService.sendToGovNotify).toHaveBeenCalledWith({
+				Message: {
+					emailAddress: "testReminder@test.com",
+					messageType: "REMINDER_EMAIL",
+				},
+			});
+			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
+			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
+		});
+	
+		it("when docType present", async () => {
+			mockF2fService.getSessionsByAuthSessionStates.mockResolvedValue(F2FSessionsWithYotiSessionWithDocumentInfo);
+	
+			const result = await reminderEmailProcessor.processRequest();
+	
+			expect(result).toEqual({ statusCode: 200, body: "Success" });
+			expect(mockLogger.info).toHaveBeenCalledWith("Total num. of users to send reminder emails to:", { numOfUsers: 2 });
+			expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
+			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
+			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(1, {"Message": {"docType": "NATIONAL_ID", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC"}});
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(2, {"Message": {"docType": "DRIVING_LICENCE", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC"}});
+			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
+			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
+		});
 	});
 
 	it("should log if no users with authSessionState F2F_YOTI_SESSION_CREATED", async () => {

--- a/src/tests/unit/services/ReminderEmailProcessor.test.ts
+++ b/src/tests/unit/services/ReminderEmailProcessor.test.ts
@@ -151,7 +151,7 @@ describe("ReminderEmailProcessor", () => {
 			mockF2fService.updateReminderEmailFlag.mockResolvedValue();
 		});
 	
-		it("when docType not present", async () => {
+		it("when documentUsed not present", async () => {
 			const result = await reminderEmailProcessor.processRequest();
 	
 			expect(result).toEqual({ statusCode: 200, body: "Success" });
@@ -169,7 +169,7 @@ describe("ReminderEmailProcessor", () => {
 			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
 		});
 	
-		it("when docType present", async () => {
+		it("when documentUsed present", async () => {
 			mockF2fService.getSessionsByAuthSessionStates.mockResolvedValue(F2FSessionsWithYotiSessionWithDocumentInfo);
 	
 			const result = await reminderEmailProcessor.processRequest();
@@ -179,8 +179,8 @@ describe("ReminderEmailProcessor", () => {
 			expect(mockF2fService.getSessionsByAuthSessionStates).toHaveBeenCalledWith(["F2F_YOTI_SESSION_CREATED", "F2F_AUTH_CODE_ISSUED", "F2F_ACCESS_TOKEN_ISSUED"]);
 			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(1, "b2ba545c-18a9-4b7e-8bc1-38a05b214a48", "PERSONIDENTITYTABLE");
 			expect(mockF2fService.getPersonIdentityById).toHaveBeenNthCalledWith(2, "b2ba545c-18a9-4b7e-8bc1-38a05b214a47", "PERSONIDENTITYTABLE");
-			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(1, { "Message": { "docType": "NATIONAL_ID", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
-			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(2, { "Message": { "docType": "DRIVING_LICENCE", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(1, { "Message": { "documentUsed": "NATIONAL_ID", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
+			expect(mockF2fService.sendToGovNotify).toHaveBeenNthCalledWith(2, { "Message": { "documentUsed": "DRIVING_LICENCE", "emailAddress": "testReminder@test.com", "firstName": "Frederick", "lastName": "Flintstone", "messageType": "REMINDER_EMAIL_DYNAMIC" } });
 			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a48", true);
 			expect(mockF2fService.updateReminderEmailFlag).toHaveBeenCalledWith("b2ba545c-18a9-4b7e-8bc1-38a05b214a47", true);
 		});

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -102,7 +102,7 @@ describe("SendEmailProcessor", () => {
 			"firstName",
 			"lastName",
 			"emailAddress",
-			"docType"
+			"docType",
 		])("Throws error when event body message is missing required attributes", async (attribute) => {
 			const eventBody = JSON.parse(dynamicEmailEvent.Records[0].body);
 			const eventBodyMessage = eventBody.Message;

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -1,7 +1,7 @@
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
-import { VALID_SQS_EVENT } from "../data/sqs-events";
+import { VALID_SQS_EVENT, VALID_DYNAMIC_REMINDER_SQS_EVENT, VALID_REMINDER_SQS_EVENT } from "../data/sqs-events";
 import { SendEmailProcessor } from "../../../services/SendEmailProcessor";
 import { SendEmailService } from "../../../services/SendEmailService";
 import { mock } from "jest-mock-extended";
@@ -19,6 +19,8 @@ const logger = new Logger({
 });
 const metrics = new Metrics({ namespace: "F2F" });
 let sqsEvent: SQSEvent;
+let reminderEmailEvent: SQSEvent;
+let dynamicEmailEvent: SQSEvent;
 
 describe("SendEmailProcessor", () => {
 	beforeAll(() => {
@@ -27,6 +29,8 @@ describe("SendEmailProcessor", () => {
 		// @ts-ignore
 		sendEmailProcessorTest.govNotifyService = mockGovNotifyService;
 		sqsEvent = VALID_SQS_EVENT;
+		reminderEmailEvent = VALID_REMINDER_SQS_EVENT;
+		dynamicEmailEvent = VALID_DYNAMIC_REMINDER_SQS_EVENT;
 	});
 
 	beforeEach(() => {
@@ -34,27 +38,78 @@ describe("SendEmailProcessor", () => {
 		sqsEvent = VALID_SQS_EVENT;
 	});
 
-	it("Returns success response when all required Email attributes exists", async () => {
-		const expectedDateTime = new Date().toISOString();
-		const mockEmailResponse = new EmailResponse(expectedDateTime, "", 201);
-		mockGovNotifyService.sendYotiPdfEmail.mockResolvedValue(mockEmailResponse);
-		const eventBody = JSON.parse(sqsEvent.Records[0].body);
-		const emailResponse = await sendEmailProcessorTest.processRequest(eventBody);
+	describe("PDF_EMAIL", () => {
+		it("Returns success response when all required Email attributes exists", async () => {
+			const expectedDateTime = new Date().toISOString();
+			const mockEmailResponse = new EmailResponse(expectedDateTime, "", 201);
+			mockGovNotifyService.sendYotiPdfEmail.mockResolvedValue(mockEmailResponse);
+			const eventBody = JSON.parse(sqsEvent.Records[0].body);
+			const emailResponse = await sendEmailProcessorTest.processRequest(eventBody);
 
-		expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
-		expect(emailResponse?.emailFailureMessage).toBe("");
+			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
+			expect(emailResponse?.emailFailureMessage).toBe("");
+		});
+
+		it.each([
+			"firstName",
+			"lastName",
+			"emailAddress",
+		])("Throws error when event body message is missing required attributes", async (attribute) => {
+			const eventBody = JSON.parse(sqsEvent.Records[0].body);
+			const eventBodyMessage = eventBody.Message;
+			delete eventBodyMessage[attribute];
+			eventBody.Message = eventBodyMessage;
+			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+		});
 	});
 
-	it.each([
-		"firstName",
-		"lastName",
-		"emailAddress",
-	])("Throws error when event body message is missing required attributes", async (attribute) => {
-		const eventBody = JSON.parse(sqsEvent.Records[0].body);
-		const eventBodyMessage = eventBody.Message;
-		delete eventBodyMessage[attribute];
-		eventBody.Message = eventBodyMessage;
-		await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+	describe("REMINDER_EMAIL", () => {
+		it("Returns success response when all required Email attributes exists", async () => {
+			const expectedDateTime = new Date().toISOString();
+			const mockEmailResponse = new EmailResponse(expectedDateTime, "", 201);
+			mockGovNotifyService.sendReminderEmail.mockResolvedValue(mockEmailResponse);
+			const eventBody = JSON.parse(reminderEmailEvent.Records[0].body);
+			const emailResponse = await sendEmailProcessorTest.processRequest(eventBody);
+
+			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
+			expect(emailResponse?.emailFailureMessage).toBe("");
+		});
+
+		it.each([
+			"emailAddress",
+		])("Throws error when event body message is missing required attributes", async (attribute) => {
+			const eventBody = JSON.parse(reminderEmailEvent.Records[0].body);
+			const eventBodyMessage = eventBody.Message;
+			delete eventBodyMessage[attribute];
+			eventBody.Message = eventBodyMessage;
+			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+		});
+	});
+
+	describe("REMINDER_EMAIL_DYNAMIC", () => {
+		it("Returns success response when all required Email attributes exists", async () => {
+			const expectedDateTime = new Date().toISOString();
+			const mockEmailResponse = new EmailResponse(expectedDateTime, "", 201);
+			mockGovNotifyService.sendDynamicReminderEmail.mockResolvedValue(mockEmailResponse);
+			const eventBody = JSON.parse(dynamicEmailEvent.Records[0].body);
+			const emailResponse = await sendEmailProcessorTest.processRequest(eventBody);
+
+			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
+			expect(emailResponse?.emailFailureMessage).toBe("");
+		});
+
+		it.each([
+			"firstName",
+			"lastName",
+			"emailAddress",
+			"docType"
+		])("Throws error when event body message is missing required attributes", async (attribute) => {
+			const eventBody = JSON.parse(dynamicEmailEvent.Records[0].body);
+			const eventBodyMessage = eventBody.Message;
+			delete eventBodyMessage[attribute];
+			eventBody.Message = eventBodyMessage;
+			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+		});
 	});
 
 });

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -102,7 +102,7 @@ describe("SendEmailProcessor", () => {
 			"firstName",
 			"lastName",
 			"emailAddress",
-			"docType",
+			"documentUsed",
 		])("Throws error when event body message is missing required attributes", async (attribute) => {
 			const eventBody = JSON.parse(dynamicEmailEvent.Records[0].body);
 			const eventBodyMessage = eventBody.Message;

--- a/src/tests/unit/services/SendEmailService.test.ts
+++ b/src/tests/unit/services/SendEmailService.test.ts
@@ -217,7 +217,7 @@ describe("SendEmailProcessor", () => {
 		const emailResponse = await sendEmailServiceTest.sendReminderEmail(email);
 
 		expect(mockGovNotify.sendEmail).toHaveBeenCalledTimes(1);
-		expect(mockGovNotify.sendEmail).toHaveBeenCalledWith("1490de9b-d986-4404-b260-ece7f1837115", "example@test.com", {"reference": expect.any(String)});
+		expect(mockGovNotify.sendEmail).toHaveBeenCalledWith("1490de9b-d986-4404-b260-ece7f1837115", "example@test.com", { "reference": expect.any(String) });
 		expect(emailResponse.emailFailureMessage).toBe("");
 	});
 
@@ -229,7 +229,7 @@ describe("SendEmailProcessor", () => {
 		const emailResponse = await sendEmailServiceTest.sendDynamicReminderEmail(email);
 
 		expect(mockGovNotify.sendEmail).toHaveBeenCalledTimes(1);
-		expect(mockGovNotify.sendEmail).toHaveBeenCalledWith("1490de9b-d986-4404-b260-ece7f1837116", "bhavana.hemanth@digital.cabinet-office.gov.uk", {"personalisation": {"chosen photo ID": "PASSPORT", "first name": "Frederick", "last name": "Flintstone"}, "reference": expect.any(String)});
+		expect(mockGovNotify.sendEmail).toHaveBeenCalledWith("1490de9b-d986-4404-b260-ece7f1837116", "bhavana.hemanth@digital.cabinet-office.gov.uk", { "personalisation": { "chosen photo ID": "PASSPORT", "first name": "Frederick", "last name": "Flintstone" }, "reference": expect.any(String) });
 		expect(emailResponse.emailFailureMessage).toBe("");
 	});
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -63,6 +63,8 @@ export class Constants {
 	static readonly PDF_EMAIL = "PDF_EMAIL";
 
 	static readonly REMINDER_EMAIL = "REMINDER_EMAIL";
+	
+	static readonly REMINDER_EMAIL_DYNAMIC = "REMINDER_EMAIL_DYNAMIC";
 
 	static readonly EMAIL_DISABLED = "EMAIL_DISABLED";
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -83,5 +83,15 @@ export class Constants {
   static readonly IDENTITY_CHECK_CREDENTIAL = "IdentityCheckCredential";
 
   static readonly URN_UUID_PREFIX = "urn:uuid:";
+
+	static readonly FIRST_NAME = "first name";
+
+	static readonly GOV_NOTIFY_OPTIONS = {
+		FIRST_NAME: "first name",
+		LAST_NAME: "last name",
+		LINK_TO_FILE: "link_to_file",
+		CHOSEN_PHOTO_ID: "chosen photo ID"
+
+	};
   
 }

--- a/src/utils/GovNotifyEvent.ts
+++ b/src/utils/GovNotifyEvent.ts
@@ -23,7 +23,7 @@ export interface ReminderEmailEventDynamic {
 	"Message": {
 		"firstName": string;
 		"lastName": string;
-		"docType": string;
+		"documentUsed": string;
 		"emailAddress": string;
 		"messageType": string;
 	};
@@ -55,14 +55,14 @@ export const buildReminderEmailEventFields = (emailAddress: string): ReminderEma
 	};
 };
 
-export const buildDynamicReminderEmailEventFields = (emailAddress: string, firstName: string, lastName: string, docType: string): ReminderEmailEventDynamic => {
+export const buildDynamicReminderEmailEventFields = (emailAddress: string, firstName: string, lastName: string, documentUsed: string): ReminderEmailEventDynamic => {
 
 	return {
 		Message : {
 			emailAddress,
 			firstName,
 			lastName,
-			docType,
+			documentUsed,
 			messageType: Constants.REMINDER_EMAIL_DYNAMIC,
 		},
 	};

--- a/src/utils/GovNotifyEvent.ts
+++ b/src/utils/GovNotifyEvent.ts
@@ -19,6 +19,15 @@ export interface ReminderEmailEvent {
 		"messageType": string;
 	};
 }
+export interface ReminderEmailEventDynamic {
+	"Message": {
+		"firstName": string;
+		"lastName": string;
+		"docType": string;
+		"emailAddress": string;
+		"messageType": string;
+	};
+}
 
 
 export const buildGovNotifyEventFields = (sessionId: string, yotiSessionId: string, personDetails: PersonIdentityItem): GovNotifyEvent => {
@@ -42,6 +51,19 @@ export const buildReminderEmailEventFields = (emailAddress: string): ReminderEma
 		Message : {
 			emailAddress,
 			messageType: Constants.REMINDER_EMAIL,
+		},
+	};
+};
+
+export const buildDynamicReminderEmailEventFields = (emailAddress: string, firstName: string, lastName: string, docType: string): ReminderEmailEventDynamic => {
+
+	return {
+		Message : {
+			emailAddress,
+			firstName,
+			lastName,
+			docType,
+			messageType: Constants.REMINDER_EMAIL_DYNAMIC,
 		},
 	};
 };


### PR DESCRIPTION
## Proposed changes

### What changed

- Saves users selected Document Type to the Session Table
- Adds users selected Document Type, FirstName and LastName to the Reminder Email Template
- Conditionally sends either the static or dynamic email template based on available data

### Issue tracking
https://govukverify.atlassian.net/browse/KIWI-1227