### PR TITLE
[KIWI-1797] Fixes the YotiCallbackRetriesExceededErrorAlarm 

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3050,7 +3050,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ThankYouEmailFunctionLogGroup
-      FilterPattern: '{ $.level = "ERROR" || $.messageCode = "YOTI_RETRIES_EXCEEDED" }'
+      FilterPattern: '{ $.level = "ERROR" && $.messageCode = "YOTI_RETRIES_EXCEEDED" }'
       MetricTransformations:
         -
           MetricValue: "1"
@@ -3245,7 +3245,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref YotiCallbackFunctionLogGroup
-      FilterPattern: '{ $.level = "ERROR" || $.messageCode = "YOTI_RETRIES_EXCEEDED" }'
+      FilterPattern: '{ $.level = "ERROR" && $.messageCode = "YOTI_RETRIES_EXCEEDED" }'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Updating the filter query for YotiCallbackRetriesExceededErrorAlarm such that alarms will be triggered only when error occurs with YOTI_RETRIES_EXCEEDED messageCode.

### Why did it change
Identified a bug in production alarms due to a change done as part of KIWI-1687

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1797](https://govukverify.atlassian.net/browse/KIWI-1797)



[KIWI-1797]: https://govukverify.atlassian.net/browse/KIWI-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ