### PR TITLE
KIWI-2585 fix for FIRST_BRANCH_VISIT yoti notification

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -1206,6 +1206,7 @@ components:
             - "check_completion"
             - "session_completion"
             - "thank_you_email_requested"
+            - "first_branch_visit"
           description: indicates notification message type
           example: "session_completion"
         task_id:

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -62,7 +62,7 @@ interface KidOptions {
 	journeyType: 'invalidSigningKid' | 'missingSigningKid';
 }
 
-export async function stubStartPost(stubPayload: StubStartRequest, options?: KidOptions): Promise<AxiosResponse<StubStartResponse>> {
+export async function stubStartPost(stubPayload: StubStartRequest, options?: KidOptions, expectedStatus = 200): Promise<AxiosResponse<StubStartResponse>> {
 	const path = constants.DEV_IPV_F2F_STUB_URL! + "start";
   
 	if (constants.THIRD_PARTY_CLIENT_ID) {
@@ -79,15 +79,18 @@ export async function stubStartPost(stubPayload: StubStartRequest, options?: Kid
   
 	try {
 	  const postRequest = await axios.post(path, stubPayload);
-	  expect(postRequest.status).toBe(200);
+	  expect(postRequest.status).toBe(expectedStatus);
 	  return postRequest;
 	} catch (error: any) {
 	  console.error(`Error response from ${path} endpoint: ${error}`);
+	  if (error.response) {
+		  expect(error.response.status).toBe(expectedStatus);
+	  }
 	  return error.response;
 	}
 }
 
-export async function startTokenPost(options?: KidOptions): Promise<AxiosResponse<string>> {
+export async function startTokenPost(options?: KidOptions, expectedStatus = 200): Promise<AxiosResponse<string>> {
 	const path = constants.DEV_IPV_F2F_STUB_URL! + "generate-token-request";
 	let postRequest: AxiosResponse<string>;
 
@@ -98,6 +101,9 @@ export async function startTokenPost(options?: KidOptions): Promise<AxiosRespons
 			postRequest = await axios.post(path, payload);
 		} catch (error: any) {
 			console.error(`Error response from ${path} endpoint: ${error}`);
+			if (error.response) {
+				expect(error.response.status).toBe(expectedStatus);
+			}
 			return error.response;
 		}
 	} else {
@@ -105,46 +111,58 @@ export async function startTokenPost(options?: KidOptions): Promise<AxiosRespons
 			postRequest = await axios.post(path);
 		} catch (error: any) {
 			console.error(`Error response from ${path} endpoint: ${error}`);
+			if (error.response) {
+				expect(error.response.status).toBe(expectedStatus);
+			}
 			return error.response;
 		}
 	}
 
-	expect(postRequest.status).toBe(200);
+	expect(postRequest.status).toBe(expectedStatus);
 	return postRequest;
 }
 
-export async function sessionPost(clientId: string, request: string): Promise<AxiosResponse<SessionResponse>> {
+export async function sessionPost(clientId: string, request: string, expectedStatus = 200): Promise<AxiosResponse<SessionResponse>> {
 	const path = "/session";
 	try {
 		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request }, { headers: { "x-forwarded-for": "ip-address", "txma-audit-encoded": "encoded-header" } });
-		expect(postRequest.status).toBe(200);
+		expect(postRequest.status).toBe(expectedStatus);
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function personInfoGet(sessionId: string): Promise<AxiosResponse<string>> {
+export async function personInfoGet(sessionId: string, expectedStatus = 200): Promise<AxiosResponse<string>> {
 	const path = "/person-info";
 	try {
 		const getRequest = await API_INSTANCE.get(path, { headers: { "x-govuk-signin-session-id": sessionId, "txma-audit-encoded": "encoded-header" } });
-		expect(getRequest.status).toBe(200);
+		expect(getRequest.status).toBe(expectedStatus);
 		return getRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function personInfoKeyGet(): Promise<AxiosResponse<{ key: string }>> {
+export async function personInfoKeyGet(expectedStatus = 200): Promise<AxiosResponse<{ key: string }>> {
 	const path = "/person-info-key";
 	try {
 		const getRequest = await API_INSTANCE.get(path);
-		expect(getRequest.status).toBe(200);
+		expect(getRequest.status).toBe(expectedStatus);
 		return getRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}.`);
+		if (error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
@@ -157,73 +175,108 @@ export function validatePersonInfoResponse(personInfoKey: string, personInfoResp
 }
 
 
-export async function postDocumentSelection(userData: DocSelectionData, sessionId: string): Promise<AxiosResponse<string>> {
+export async function postDocumentSelection(userData: DocSelectionData, sessionId: string, expectedStatus?: number): Promise<AxiosResponse<string>> {
 	const path = "/documentSelection";
 	try {
 		const postRequest = await API_INSTANCE.post(path, userData, { headers: { "x-govuk-signin-session-id": sessionId, "txma-audit-encoded": "encoded-header" } });
+		if (expectedStatus !== undefined) {
+			expect(postRequest.status).toBe(expectedStatus);
+		}
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (expectedStatus !== undefined && error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
 
-export async function authorizationGet(sessionId: string): Promise<AxiosResponse<AuthorizationResponse>> {
+export async function authorizationGet(sessionId: string, expectedStatus?: number): Promise<AxiosResponse<AuthorizationResponse>> {
 	const path = "/authorization";
 	try {
 		const getRequest = await API_INSTANCE.get(path, { headers: { "session-id": sessionId } });
+		if (expectedStatus !== undefined) {
+			expect(getRequest.status).toBe(expectedStatus);
+		}
 		return getRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (expectedStatus !== undefined && error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function tokenPost(authCode: string, redirectUri: string, clientAssertionJwt: string, clientAssertionType?: string): Promise<AxiosResponse<TokenResponse>> {
+export async function tokenPost(authCode: string, redirectUri: string, clientAssertionJwt: string, clientAssertionType?: string, expectedStatus?: number): Promise<AxiosResponse<TokenResponse>> {
 	const path = "/token";
 	const assertionType = clientAssertionType || Constants.CLIENT_ASSERTION_TYPE_JWT_BEARER;
 	try {
 		const postRequest = await API_INSTANCE.post(path, `code=${authCode}&grant_type=authorization_code&redirect_uri=${redirectUri}&client_assertion_type=${assertionType}&client_assertion=${clientAssertionJwt}`, { headers: { "Content-Type": "text/plain" } });
+		if (expectedStatus !== undefined) {
+			expect(postRequest.status).toBe(expectedStatus);
+		}
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (expectedStatus !== undefined && error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function userInfoPost(accessToken: string): Promise<AxiosResponse<UserInfoResponse>> {
+export async function userInfoPost(accessToken: string, expectedStatus?: number): Promise<AxiosResponse<UserInfoResponse>> {
 	const path = "/userinfo";
 	try {
 		const postRequest = await API_INSTANCE.post(path, null, { headers: { "Authorization": `${accessToken}` } });
+		if (expectedStatus !== undefined) {
+			expect(postRequest.status).toBe(expectedStatus);
+		}
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (expectedStatus !== undefined && error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function callbackPost(sessionId?: string, topic = "session_completion"): Promise<void> {
+export async function callbackPost(sessionId?: string, topic = "session_completion", expectedStatus = 200): Promise<AxiosResponse<string>> {
 	const path = "/callback";
 	if (!sessionId) throw new Error("no yoti session ID provided");
 	try {
-		await API_INSTANCE.post(path, {
+		const postRequest = await API_INSTANCE.post(path, {
 			session_id: sessionId,
 			topic,
 		});
+		expect(postRequest.status).toBe(expectedStatus);
+		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }
 
-export async function sessionConfigurationGet(sessionId: string): Promise<AxiosResponse<SessionConfigResponse>> {
+export async function sessionConfigurationGet(sessionId: string, expectedStatus?: number): Promise<AxiosResponse<SessionConfigResponse>> {
 	const path = "/sessionConfiguration";
 	try {
 		const getRequest = await API_INSTANCE.get(path, { headers: { "x-govuk-signin-session-id": sessionId } });
+		if (expectedStatus !== undefined) {
+			expect(getRequest.status).toBe(expectedStatus);
+		}
 		return getRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
+		if (expectedStatus !== undefined && error.response) {
+			expect(error.response.status).toBe(expectedStatus);
+		}
 		return error.response;
 	}
 }

--- a/src/tests/api/backend/CallbackApi.test.ts
+++ b/src/tests/api/backend/CallbackApi.test.ts
@@ -20,6 +20,7 @@ import { constants } from "../ApiConstants";
 import { getTxmaEventsFromTestHarness, validateTxMAEventData } from "../ApiUtils";
 import { DocSelectionData } from "../types";
 import { AuthSessionState } from "../../../models/enums/AuthSessionState";
+import { YotiCallbackTopics } from "../../../models/enums/YotiCallbackTopics";
 
 //QualityGateIntegrationTest 
 //QualityGateRegressionTest
@@ -73,7 +74,7 @@ describe("/callback endpoint", () => {
 		const session = await getSessionById(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME);
 		const yotiSessionId = session?.yotiSessionId;
 		expect(yotiSessionId).toBeTruthy();
-		await callbackPost(yotiSessionId);
+		await callbackPost(yotiSessionId, YotiCallbackTopics.SESSION_COMPLETION, 200);
 		let sqsMessage;
 		let i = 0;
 		do {
@@ -100,7 +101,7 @@ describe("/callback endpoint", () => {
 			const yotiSessionId = session?.yotiSessionId;
 			expect(yotiSessionId).toBeTruthy();
 		
-			await callbackPost(yotiSessionId);
+			await callbackPost(yotiSessionId, YotiCallbackTopics.SESSION_COMPLETION, 200);
 	
 			let sqsMessage;
 			let i = 0;
@@ -138,7 +139,7 @@ describe("/callback endpoint", () => {
 		const yotiSessionId = session?.yotiSessionId;
 		expect(yotiSessionId).toBeTruthy();
 	
-		await callbackPost(yotiSessionId);
+		await callbackPost(yotiSessionId, YotiCallbackTopics.SESSION_COMPLETION, 200);
 
 		let sqsMessage;
 		let i = 0;
@@ -168,7 +169,7 @@ describe("/callback endpoint", () => {
 		const yotiSessionId = session?.yotiSessionId;
 		expect(yotiSessionId).toBeTruthy();
 
-		await callbackPost(yotiSessionId);
+		await callbackPost(yotiSessionId, YotiCallbackTopics.SESSION_COMPLETION, 200);
 
 		const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 7);
 		validateTxMAEventData({ eventName: "F2F_CRI_START", schemaName: "F2F_CRI_START_SCHEMA" }, allTxmaEventBodies);
@@ -192,7 +193,7 @@ describe("/callback endpoint", () => {
 		const yotiSessionId = session?.yotiSessionId;
 		expect(yotiSessionId).toBeTruthy();
 	
-		await callbackPost(yotiSessionId);
+		await callbackPost(yotiSessionId, YotiCallbackTopics.SESSION_COMPLETION, 200);
 
 		const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 6);
 		validateTxMAEventData({ eventName: "F2F_CRI_START", schemaName: "F2F_CRI_START_SCHEMA" }, allTxmaEventBodies);
@@ -216,10 +217,19 @@ describe("/callback endpoint", () => {
 		expect(yotiSessionId).toBeTruthy();
 		expect(sessionBefore?.authSessionState).toBeTruthy();
 
-		await callbackPost(yotiSessionId, "first_branch_visit");
+		await callbackPost(yotiSessionId, YotiCallbackTopics.FIRST_BRANCH_VISIT, 200);
 
 		const sessionAfter = await getSessionById(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME);
 		expect(sessionAfter?.authSessionState).toBe(sessionBefore?.authSessionState);
 		expect(sessionAfter?.authSessionState).not.toBe(AuthSessionState.F2F_CREDENTIAL_ISSUED);
+
+		const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 2);
+		validateTxMAEventData({ eventName: "F2F_CRI_START", schemaName: "F2F_CRI_START_SCHEMA" }, allTxmaEventBodies);
+		validateTxMAEventData({ eventName: "F2F_YOTI_START", schemaName: "F2F_YOTI_START_SCHEMA" }, allTxmaEventBodies);
+		validateTxMAEventData({ eventName: "F2F_CRI_AUTH_CODE_ISSUED", schemaName: "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" }, allTxmaEventBodies);
+		validateTxMAEventData({ eventName: "F2F_CRI_END", schemaName: "F2F_CRI_END_SCHEMA" }, allTxmaEventBodies);
+		expect(allTxmaEventBodies.F2F_YOTI_RESPONSE_RECEIVED).toBeUndefined();
+		expect(allTxmaEventBodies.F2F_CRI_VC_ISSUED).toBeUndefined();
+		expect(allTxmaEventBodies.F2F_DOCUMENT_UPLOADED).toBeUndefined();
 	}, 20000);
 });

--- a/src/tests/api/backend/HappyPath.test.ts
+++ b/src/tests/api/backend/HappyPath.test.ts
@@ -126,7 +126,7 @@ describe("/documentSelection Endpoint", () => {
 		newf2fStubPayload.yotiMockID = yotiMockId;
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-		await postDocumentSelection(docSelectionData, sessionId);
+		await postDocumentSelection(docSelectionData, sessionId, 200);
 
 		const session = await getSessionById(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME);
 		expect(session?.authSessionState).toBe("F2F_YOTI_SESSION_CREATED");
@@ -334,9 +334,9 @@ describe("/authorization endpoint", () => {
 		newf2fStubPayload.yotiMockID = yotiMockId;
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-		await postDocumentSelection(docSelectionData, sessionId);
+		await postDocumentSelection(docSelectionData, sessionId, 200);
 
-		const authResponse = await authorizationGet(sessionId);
+		const authResponse = await authorizationGet(sessionId, 200);
 		expect(authResponse.status).toBe(200);
 
 		await getSessionAndVerifyKey(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME, "authSessionState", "F2F_AUTH_CODE_ISSUED");
@@ -365,11 +365,11 @@ describe("/token endpoint", () => {
 		newf2fStubPayload.yotiMockID = yotiMockId;
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-		await postDocumentSelection(docSelectionData, sessionId);
+		await postDocumentSelection(docSelectionData, sessionId, 200);
 
-		const authResponse = await authorizationGet(sessionId);
+		const authResponse = await authorizationGet(sessionId, 200);
 		const startTokenResponse = await startTokenPost();
-		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
+		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data, undefined, 200);
 		expect(tokenResponse.status).toBe(200);
 
 
@@ -390,13 +390,13 @@ describe("/userinfo endpoint", () => {
 		newf2fStubPayload.yotiMockID = yotiMockId;
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-		await postDocumentSelection(docSelectionData, sessionId);
+		await postDocumentSelection(docSelectionData, sessionId, 200);
 
-		const authResponse = await authorizationGet(sessionId);
+		const authResponse = await authorizationGet(sessionId, 200);
 
 		const startTokenResponse = await startTokenPost();
 		
-		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
+		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data, undefined, 200);
 
 		const userInfoResponse = await userInfoPost("Bearer " + tokenResponse.data.access_token);
 		expect(userInfoResponse.status).toBe(202);
@@ -492,7 +492,7 @@ describe("Expired User Sessions", () => {
 		const postRequest = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		const sessionId = postRequest.data.session_id;
 		console.log(sessionId);
-		await postDocumentSelection(dataUkDrivingLicence, sessionId);
+		await postDocumentSelection(dataUkDrivingLicence, sessionId, 200);
 
 		const newCreatedDateTimestamp = getEpochTimestampXDaysAgo(22);
 		await updateDynamoDbRecord(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME, "createdDate", newCreatedDateTimestamp, "N");

--- a/src/tests/api/backend/UnhappyPath.test.ts
+++ b/src/tests/api/backend/UnhappyPath.test.ts
@@ -34,7 +34,7 @@ describe("Unhappy Path Tests", () => {
 			newf2fStubPayload.shared_claims.name[0].nameParts[0].value = "";
 			newf2fStubPayload.shared_claims.name[0].nameParts[1].value = "";
 			const stubResponse = await stubStartPost(newf2fStubPayload);
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -44,7 +44,7 @@ describe("Unhappy Path Tests", () => {
 			newf2fStubPayload.yotiMockID = "";
 			newf2fStubPayload.shared_claims.name[0].nameParts[2].value = "";
 			const stubResponse = await stubStartPost(newf2fStubPayload);
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -53,7 +53,7 @@ describe("Unhappy Path Tests", () => {
 			const newf2fStubPayload = structuredClone(f2fStubPayload);
 			newf2fStubPayload.shared_claims.emailAddress = "";
 			const stubResponse = await stubStartPost(newf2fStubPayload);
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -62,14 +62,14 @@ describe("Unhappy Path Tests", () => {
 			const newf2fStubPayload = structuredClone(f2fStubPayload);
 			newf2fStubPayload.shared_claims.address[0].addressCountry = "XY";
 			const stubResponse = await stubStartPost(newf2fStubPayload);
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
 
 		it("Unsuccessful Request Tests - Incorrect Address Format", async () => {
 			const stubResponse = await stubStartPost(addressSessionPayload as StubStartRequest);
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -77,7 +77,7 @@ describe("Unhappy Path Tests", () => {
 		it("Unsuccessful Request Tests - Invalid Kid Test", async () => {
 			const newf2fStubPayload = structuredClone(f2fStubPayload);
 			const stubResponse = await stubStartPost(newf2fStubPayload, { journeyType: 'invalidSigningKid' });
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -85,7 +85,7 @@ describe("Unhappy Path Tests", () => {
 		it("Unsuccessful Request Tests - Missing Kid Test", async () => {
 			const newf2fStubPayload = structuredClone(f2fStubPayload);
 			const stubResponse = await stubStartPost(newf2fStubPayload, { journeyType: 'missingSigningKid' });
-			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+			const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request, 401);
 			expect(sessionResponse.status).toBe(401);
 			expect(sessionResponse.data).toBe("Unauthorized");
 		});
@@ -95,7 +95,7 @@ describe("Unhappy Path Tests", () => {
 
 		it("Unsuccessful Request Tests - 4XX Returned", async () => {
 			const sessionId = randomUUID();
-			const personInfoResponse = await personInfoGet(sessionId);
+			const personInfoResponse = await personInfoGet(sessionId, 401);
 			expect(personInfoResponse.status).toBe(401);
 			expect(personInfoResponse.data).toBe(`No session found with the session id: ${sessionId}`);	
 		});
@@ -142,11 +142,11 @@ describe("Unhappy Path Tests", () => {
 			newf2fStubPayload.yotiMockID = "0000";
 			const { sessionId: newSessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 			sessionId = newSessionId;
-			await postDocumentSelection(dataPassport, sessionId);
+			await postDocumentSelection(dataPassport, sessionId, 200);
 		});
 
 		it("Unsuccessful Request Tests - Invalid Kid in Token JWT", async () => {
-			const authResponse = await authorizationGet(sessionId);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const startTokenResponse = await startTokenPost({ journeyType: 'invalidSigningKid' });
 			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
 			expect(tokenResponse.status).toBe(401);
@@ -154,7 +154,7 @@ describe("Unhappy Path Tests", () => {
 		});
 
 		it("Unsuccessful Request Tests - Missing Kid in Token JWT", async () => {
-			const authResponse = await authorizationGet(sessionId);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const startTokenResponse = await startTokenPost({ journeyType: 'missingSigningKid' });
 			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
 			expect(tokenResponse.status).toBe(401);
@@ -162,14 +162,14 @@ describe("Unhappy Path Tests", () => {
 		});
 
 		it("Unsuccessful Request Tests - Request does not include client_assertion", async () => {
-			const authResponse = await authorizationGet(sessionId);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, "");
 			expect(tokenResponse.status).toBe(401);
 			expect(tokenResponse.data).toBe("Invalid request: Missing client_assertion parameter");
 		});
 
 		it("Unsuccessful Request Tests - Request does not include client_assertion_type", async () => {
-			const authResponse = await authorizationGet(sessionId);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const startTokenResponse = await startTokenPost();
 			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data, " ");
 			expect(tokenResponse.status).toBe(401);
@@ -189,10 +189,10 @@ describe("Unhappy Path Tests", () => {
 		});
 
 		it("Unsuccessful Request Tests - Invalid Signature", async () => {
-			await postDocumentSelection(dataPassport, sessionId);
-			const authResponse = await authorizationGet(sessionId);
+			await postDocumentSelection(dataPassport, sessionId, 200);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const startTokenResponse = await startTokenPost();
-			await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
+			await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data, undefined, 200);
 			const userInfoResponse = await userInfoPost("Bearer 123");
 
 			expect(userInfoResponse.status).toBe(400);
@@ -200,10 +200,10 @@ describe("Unhappy Path Tests", () => {
 		});
 
 		it("Unsuccessful Request Tests - Invalid Authorization Header", async () => {
-			await postDocumentSelection(dataPassport, sessionId);
-			const authResponse = await authorizationGet(sessionId);
+			await postDocumentSelection(dataPassport, sessionId, 200);
+			const authResponse = await authorizationGet(sessionId, 200);
 			const startTokenResponse = await startTokenPost();
-			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data);
+			const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri, startTokenResponse.data, undefined, 200);
 			const userInfoResponse = await userInfoPost(tokenResponse.data.access_token);
 
 			expect(userInfoResponse.status).toBe(400);


### PR DESCRIPTION
### What changed

Updated test http outcome assertions and added new first branch visit topic to api spec
### Why did it change

Previous First Branch Visit notification subscription change didn't include the updated new topic for the yoti subscription, furthermore api tests did not assert what the outcome of http codes where and did not correctly throw on 400

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2585](https://govukverify.atlassian.net/browse/KIWI-2585)



[KIWI-2585]: https://govukverify.atlassian.net/browse/KIWI-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ