### PR TITLE
[KIWI-2609] - Axios upgrade

### DIFF
--- a/f2f-ipv-stub/src/package-lock.json
+++ b/f2f-ipv-stub/src/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-kms": "3.1001.0",
         "@smithy/node-http-handler": "4.0.4",
         "@types/js-yaml": "4.0.9",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.2",
         "node-jose": "2.2.0"
@@ -5623,14 +5623,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -9301,10 +9301,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/f2f-ipv-stub/src/package.json
+++ b/f2f-ipv-stub/src/package.json
@@ -7,7 +7,7 @@
     "@aws-sdk/client-kms": "3.1001.0",
     "@smithy/node-http-handler": "4.0.4",
     "@types/js-yaml": "4.0.9",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "ecdsa-sig-formatter": "1.0.11",
     "esbuild": "0.25.2",
     "node-jose": "2.2.0"

--- a/gov-notify-stub/src/package-lock.json
+++ b/gov-notify-stub/src/package-lock.json
@@ -18,7 +18,7 @@
         "@aws-sdk/credential-providers": "3.1001.0",
         "@aws-sdk/lib-dynamodb": "3.1001.0",
         "aws-xray-sdk-core": "3.4.1",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "class-validator": "0.14.0",
         "esbuild": "0.25.2",
         "pdf-lib": "1.17.1"
@@ -4846,14 +4846,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -9772,10 +9772,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/gov-notify-stub/src/package.json
+++ b/gov-notify-stub/src/package.json
@@ -15,7 +15,7 @@
     "@aws-sdk/credential-providers": "3.1001.0",
     "@aws-sdk/lib-dynamodb": "3.1001.0",
     "aws-xray-sdk-core": "3.4.1",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "class-validator": "0.14.0",
     "esbuild": "0.25.2",
     "pdf-lib": "1.17.1"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -23,7 +23,7 @@
         "@smithy/node-http-handler": "4.0.4",
         "@types/node-jose": "1.1.13",
         "aws-xray-sdk-core": "3.10.3",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "body-parser": "2.2.2",
         "class-validator": "0.14.3",
         "dotenv-cli": "7.4.4",
@@ -7650,14 +7650,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -15214,10 +15214,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",

--- a/src/package.json
+++ b/src/package.json
@@ -20,7 +20,7 @@
     "@smithy/node-http-handler": "4.0.4",
     "@types/node-jose": "1.1.13",
     "aws-xray-sdk-core": "3.10.3",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "body-parser": "2.2.2",
     "class-validator": "0.14.3",
     "dotenv-cli": "7.4.4",

--- a/yoti-stub/src/package-lock.json
+++ b/yoti-stub/src/package-lock.json
@@ -18,7 +18,7 @@
         "@aws-sdk/credential-providers": "3.1001.0",
         "@aws-sdk/lib-dynamodb": "3.1001.0",
         "aws-xray-sdk-core": "3.4.1",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "class-validator": "0.14.0",
         "esbuild": "0.25.2",
         "pdf-lib": "1.17.1"
@@ -5268,14 +5268,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -10345,10 +10345,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/yoti-stub/src/package.json
+++ b/yoti-stub/src/package.json
@@ -15,7 +15,7 @@
     "@aws-sdk/credential-providers": "3.1001.0",
     "@aws-sdk/lib-dynamodb": "3.1001.0",
     "aws-xray-sdk-core": "3.4.1",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "class-validator": "0.14.0",
     "esbuild": "0.25.2",
     "pdf-lib": "1.17.1"


### PR DESCRIPTION

## Proposed changes

### What changed

Bumped Axios from 1.13.5 -> 1.15.0

### Why did it change

To address critical vulnerabilities
### Issue tracking

- [KIWI-2609](https://govukverify.atlassian.net/browse/KIWI-2609)


[KIWI-2609]: https://govukverify.atlassian.net/browse/KIWI-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ