### PR TITLE
[KIWI-2673] - F2F | BE | Exclude flaky Yoti retry test from dev/build pipelines

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -47,6 +47,7 @@
     "api-pipeline": "JEST_JUNIT_OUTPUT_NAME=api-report.xml node --experimental-vm-modules ./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/backend",
     "api-traffic": "JEST_JUNIT_OUTPUT_NAME=api-report.xml node ./node_modules/.bin/jest --runInBand --testPathPattern='tests/api/backend/(HappyPath|CallbackApi)\\.test\\.ts$'",
     "test:api": "npm run prepare-dependencies && npm run compile && npm run api",
+    "test:api-pipeline": "npm run prepare-dependencies && npm run compile && npm run api-pipeline",
     "prepare-dependencies": "npm run prepare-dependencies:canvas",
     "prepare-dependencies:canvas": "cd ./node_modules/canvas && prebuild-install -r napi || node-gyp rebuild",
     "test:api-traffic": "npm run compile && npm run api-traffic",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

test:api-pipeline script added to run API test suite in pipeline that excludes Yoti retry Callback API test (1601)

### Why did it change

Retry scenario failed consistently in pipeline due to memory counter invalidation and caused blockages

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2654](https://govukverify.atlassian.net/browse/KIWI-2654)



[KIWI-2654]: https://govukverify.atlassian.net/browse/KIWI-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ