### PR TITLE
[KIWI-2673] - F2F | BE | Exclude flaky Yoti retry test from dev/build pipelines script fix

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -51,7 +51,7 @@
     "prepare-dependencies": "npm run prepare-dependencies:canvas",
     "prepare-dependencies:canvas": "cd ./node_modules/canvas && prebuild-install -r napi || node-gyp rebuild",
     "test:api-traffic": "npm run compile && npm run api-traffic",
-    "api-third-party": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml node --experimental-vm-modules ./node_modules/.bin/jest --runInBand --testPathPattern='tests/api/(backend|stub)'",
+    "api-third-party": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml node --experimental-vm-modules ./node_modules/.bin/jest --runInBand --testMatch '**/tests/api/backend/**/*Path.test.ts'",
     "test:api-third-party": "npm run compile && npm run api-third-party",
     "api-third-party-traffic": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml ./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/backend/HappyPath.test.ts",
     "test:api-third-party-traffic": "npm run compile && npm run api-third-party-traffic",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

api-third-party test script reverted to previous iteration

### Why did it change

Mistaken inclusion of stub tests caused failures in the build pipeline

### Issue tracking
- [KIWI-2673](https://govukverify.atlassian.net/browse/KIWI-2673)


[KIWI-2673]: https://govukverify.atlassian.net/browse/KIWI-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ