### PR TITLE
[KIWI-2656]-F2F | BE | Upgrade Jose to version 6

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -26,7 +26,7 @@
     "dotenv-cli": "7.4.4",
     "ecdsa-sig-formatter": "1.0.11",
     "esbuild": "0.25.9",
-    "jose": "5.10.0",
+    "jose": "6.2.3",
     "jsonpath": "1.2.1",
     "node-jose": "2.2.0",
     "node-rsa": "1.1.1",


### PR DESCRIPTION
## Proposed changes

### What changed

 "jose": "5.10.0" -> "6.2.3",
### Why did it change

 Jose will only provide security updates for V6

### Issue tracking
- [KIWI-2656](https://govukverify.atlassian.net/browse/KIWI-2656)


[KIWI-2656]: https://govukverify.atlassian.net/browse/KIWI-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ