### PR TITLE
KIWI-2732 Updating sub building logic

### DIFF
--- a/src/services/pdfGenerationService.ts
+++ b/src/services/pdfGenerationService.ts
@@ -312,6 +312,8 @@ mapToAddressLines(postalAddress: PersonIdentityAddress): string[] {
 		address.push(`${postalAddress.subBuildingName}, ${postalAddress.buildingName}`);
 	} else if (postalAddress.buildingName && !postalAddress.subBuildingName) {
 		address.push(postalAddress.buildingName);
+	} else if (postalAddress.subBuildingName && !postalAddress.buildingName) {
+		address.push(postalAddress.subBuildingName);
 	}
 	// Line 3
 	const buildingNumber = postalAddress.buildingNumber ? `${postalAddress.buildingNumber} ` : "";

--- a/src/tests/unit/services/PdfGenerationService.test.ts
+++ b/src/tests/unit/services/PdfGenerationService.test.ts
@@ -96,5 +96,125 @@ describe("PdfGenerationServiceTest", () => {
 				"F1 1SH",
 			]);
 		});
+
+		it.each<[string, PersonIdentityAddress, string[]]>([
+			[
+				"should map a flat address without a building name",
+				{
+					...person.addresses[0],
+					organisationName: "",
+					subBuildingName: "Flat 2B",
+					buildingName: "",
+					buildingNumber: "221B",
+					streetName: "Baker Street",
+					addressLocality: "London",
+					postalCode: "NW1 6XE",
+				},
+				[
+					"Flat 2B",
+					"221B Baker Street",
+					"London",
+					"NW1 6XE",
+				],
+			],
+			[
+				"should map a business unit with department and organisation names",
+				{
+					...person.addresses[0],
+					departmentName: "Accounts Payable",
+					organisationName: "Example Trading Ltd",
+					subBuildingName: "Unit 12",
+					buildingName: "Alpha House",
+					buildingNumber: "",
+					dependentStreetName: "Service Yard",
+					streetName: "Industrial Estate",
+					dependentAddressLocality: "North Quarter",
+					addressLocality: "Manchester",
+					postalCode: "M1 1AA",
+				},
+				[
+					"Accounts Payable, Example Trading Ltd",
+					"Unit 12, Alpha House",
+					"Service Yard, Industrial Estate",
+					"North Quarter, Manchester",
+					"M1 1AA",
+				],
+			],
+			[
+				"should map an apartment in a named building",
+				{
+					...person.addresses[0],
+					organisationName: "",
+					subBuildingName: "Studio 3",
+					buildingName: "The Old Mill",
+					buildingNumber: "",
+					dependentStreetName: "Mill Lane",
+					streetName: "River Road",
+					addressLocality: "Bristol",
+					postalCode: "BS1 4ST",
+				},
+				[
+					"Studio 3, The Old Mill",
+					"Mill Lane, River Road",
+					"Bristol",
+					"BS1 4ST",
+				],
+			],
+			[
+				"should map a department address without an organisation name",
+				{
+					...person.addresses[0],
+					departmentName: "Post Room",
+					organisationName: "",
+					subBuildingName: "Suite 9",
+					buildingName: "",
+					buildingNumber: "10",
+					streetName: "Market Street",
+					addressLocality: "Leeds",
+					postalCode: "LS1 1UR",
+				},
+				[
+					"Post Room",
+					"Suite 9",
+					"10 Market Street",
+					"Leeds",
+					"LS1 1UR",
+				],
+			],
+		])("%s", (_testName, postalAddress, expectedAddressLines) => {
+			const result = pdfGenerationService.mapToAddressLines(postalAddress);
+
+			expect(result).toEqual(expectedAddressLines);
+		});
+
+		it("should print the maximum of five mapped address lines", () => {
+			const result = pdfGenerationService.mapToAddressLines(personAddressAllAddressFields);
+
+			expect(result).toHaveLength(5);
+			expect(result).toEqual([
+				"Test dept, Test org",
+				"Flat 5, Sherman",
+				"32 Ocean View, Wallaby Way",
+				"Southside, Sidney",
+				"F1 1SH",
+			]);
+		});
+
+		it("should print the minimum mapped address lines when optional address fields are missing", () => {
+			const minimumPostalAddress: PersonIdentityAddress = {
+				...person.addresses[0],
+				organisationName: "",
+				buildingName: "",
+			};
+
+			const result = pdfGenerationService.mapToAddressLines(minimumPostalAddress);
+
+			expect(result).toHaveLength(3);
+			expect(result).toEqual([
+				"32 Wallaby Way",
+				"Sidney",
+				"F1 1SH",
+			]);
+		});
 	});
 });

--- a/src/tests/unit/services/PdfGenerationService.test.ts
+++ b/src/tests/unit/services/PdfGenerationService.test.ts
@@ -78,5 +78,23 @@ describe("PdfGenerationServiceTest", () => {
 				"F1 1SH",
 			]);
 		});
+
+		it("should map sub-building name correctly when building name is not present", () => {
+			const postalAddressWithoutBuildingName: PersonIdentityAddress = {
+				...person.addresses[0],
+				subBuildingName: "Flat 5",
+				buildingName: "",
+			};
+
+			const result = pdfGenerationService.mapToAddressLines(postalAddressWithoutBuildingName);
+
+			expect(result).toEqual([
+				"Test org",
+				"Flat 5",
+				"32 Wallaby Way",
+				"Sidney",
+				"F1 1SH",
+			]);
+		});
 	});
 });


### PR DESCRIPTION


## Proposed changes
Update formatting of sub-building address entries to not be dependent on whether an overarching building address is present.

### What changed

updated logic of sub-building addresses to not be dependent on the existance of an overarching building address allowing us to accuratly display the address enetered by a user and deliver to apartments/business usnits which do not use a building address and only a sub-building address

### Why did it change

we have seen an increase in the mount of returned PCL letters in our gov notify dashboard, upon inspection these were all addresses which had no building address but. sub building address - when our users enetered these addresses our logic removed the sub-building enetered as we detected no overarching building adress, this meant the letters could not be delivered with royal mail and were returned

### Issue tracking

- [KIWI-2732](https://govukverify.atlassian.net/browse/KIWI-2732)

## Checklists

Review gov notify dashboard for nect month once merged to see if there is a decrease of returned letters and - if not check new error scenarios


[KIWI-2732]: https://govukverify.atlassian.net/browse/KIWI-2732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ