### PR TITLE
KIWI-2852 powertools logger v1 to v2 migration fixing splunk log leakage

### DIFF
--- a/src/AbortHandler.ts
+++ b/src/AbortHandler.ts
@@ -27,8 +27,8 @@ export class AbortHandler implements LambdaInterface {
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 		try {
 			const { sessionId, encodedHeader } = this.validateEvent(event);

--- a/src/AccessTokenHandler.ts
+++ b/src/AccessTokenHandler.ts
@@ -25,8 +25,8 @@ export class AccessToken implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/AddressLocationsHandler.ts
+++ b/src/AddressLocationsHandler.ts
@@ -30,7 +30,7 @@ export class AddressLocationsHandler implements LambdaInterface {
 
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/AuthorizationCodeHandler.ts
+++ b/src/AuthorizationCodeHandler.ts
@@ -26,8 +26,8 @@ class AuthorizationCodeHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		let sessionId: string;

--- a/src/DocumentSelectionHandler.ts
+++ b/src/DocumentSelectionHandler.ts
@@ -30,8 +30,8 @@ export class DocumentSelection implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/ExpiredSessionsHandler.ts
+++ b/src/ExpiredSessionsHandler.ts
@@ -22,7 +22,7 @@ const metrics = new Metrics({ namespace: POWERTOOLS_METRICS_NAMESPACE, serviceNa
 class Session implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: any, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/GeneratePrintedLetterHandler.ts
+++ b/src/GeneratePrintedLetterHandler.ts
@@ -27,7 +27,7 @@ export class GeneratePrintedLetterHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: any, context: any): Promise<any> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/GenerateYotiLetterHandler.ts
+++ b/src/GenerateYotiLetterHandler.ts
@@ -33,7 +33,7 @@ export class GenerateYotiLetterHandler implements LambdaInterface {
 
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: { sessionId: string; pdfPreference: string }, context: any): Promise<any> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 		this.validateEvent(event);
 

--- a/src/GovNotifyHandler.ts
+++ b/src/GovNotifyHandler.ts
@@ -30,8 +30,8 @@ class GovNotifyHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: SQSEvent, context: Context): Promise<SQSBatchResponse> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/PersonInfoHandler.ts
+++ b/src/PersonInfoHandler.ts
@@ -31,7 +31,7 @@ export class PersonInfoHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/PersonInfoKeyHandler.ts
+++ b/src/PersonInfoKeyHandler.ts
@@ -28,8 +28,8 @@ export class PersonInfoKeyHandler implements LambdaInterface {
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
     async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-    	logger.setPersistentLogAttributes({});
-    	logger.addContext(context);
+		logger.resetKeys();
+		logger.addContext(context);
 
     	try {
     		const privateKeyPath = this.environmentVariables.privateKeySsmPath();

--- a/src/PostOfficeVisitHandler.ts
+++ b/src/PostOfficeVisitHandler.ts
@@ -32,7 +32,7 @@ class PostOfficeVisitHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: YotiCallbackPayload, context: any): Promise<void | AppError> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/ReminderEmailHandler.ts
+++ b/src/ReminderEmailHandler.ts
@@ -22,7 +22,7 @@ const metrics = new Metrics({ namespace: POWERTOOLS_METRICS_NAMESPACE, serviceNa
 class Session implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: any, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/SendToGovNotifyHandler.ts
+++ b/src/SendToGovNotifyHandler.ts
@@ -32,8 +32,8 @@ class SendToGovNotifyHandler implements LambdaInterface {
 
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: any, context: Context): Promise<any> {
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/SessionConfigHandler.ts
+++ b/src/SessionConfigHandler.ts
@@ -27,7 +27,7 @@ class SessionConfigHandler implements LambdaInterface {
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
 		try {
-			logger.setPersistentLogAttributes({});
+			logger.resetKeys();
 			logger.addContext(context);
 
 			logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/SessionHandler.ts
+++ b/src/SessionHandler.ts
@@ -26,8 +26,8 @@ class Session implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/TriggerYotiCallbackStateMachineHandler.ts
+++ b/src/TriggerYotiCallbackStateMachineHandler.ts
@@ -33,7 +33,7 @@ class TriggerYotiCallbackStateMachineHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: SQSEvent, context: any): Promise<any> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/UserInfoHandler.ts
+++ b/src/UserInfoHandler.ts
@@ -24,8 +24,8 @@ class UserInfo implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		logger.info("Ensuring service is " + POWERTOOLS_SERVICE_NAME + " deployed - " + new Date().toDateString());

--- a/src/YotiSessionCompletionHandler.ts
+++ b/src/YotiSessionCompletionHandler.ts
@@ -32,7 +32,7 @@ class YotiSessionCompletionHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: YotiCallbackPayload, context: any): Promise<void | AppError> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/tests/unit/TriggerYotiCallbackStateMachineHandler.test.ts
+++ b/src/tests/unit/TriggerYotiCallbackStateMachineHandler.test.ts
@@ -11,7 +11,7 @@ vi.mock("@aws-lambda-powertools/logger", () => ({
 			warn: vi.fn(),
 			info: vi.fn(),
 			error: vi.fn(),
-			setPersistentLogAttributes: vi.fn(),
+			resetKeys: vi.fn(),
 			addContext: vi.fn(),
 			appendKeys: vi.fn(),
 		};


### PR DESCRIPTION
## Proposed changes

### What changed

Updated Lambda handler logger reset logic for AWS Lambda Powertools Logger v2.

- Added `logger.resetKeys()` at the start of each Lambda handler invocation to clear temporary keys added with `logger.appendKeys()`. ([link](https://github.com/aws-powertools/powertools-lambda-typescript/blob/a3d3147a4629d1bfb8acd932033a683f8fd20a7b/packages/logger/src/Logger.ts#L645))
- Removed deprecated  V1 `logger.setPersistentLogAttributes({})` method 

### Why did it change

After upgrading AWS Lambda Powertools Logger from v1 to v2, temporary keys added with `appendKeys()` are not cleared by resetting persistent log attributes with `logger.setPersistentLogAttributes();`. [link](https://docs.aws.amazon.com/powertools/typescript/2.8.0/api/classes/_aws_lambda_powertools_logger.index.Logger.html#setPersistentLogAttributes:~:text=Logger.ts%3A562-,setPersistentLogAttributes,-setPersistentLog)

Because our keys are not being properly cleared, when in a warm Lambda execution environment, identifiers such as session or journey IDs remain on the shared logger instance and appear in later invocation logs. This change explicitly clears temporary logger keys at the start of each invocation, preventing logger context from leaking between executions without rolling back the Powertools version bump.

### Issue tracking

- [KIWI-2852](https://govukverify.atlassian.net/browse/KIWI-2852)

[KIWI-2852]: https://govukverify.atlassian.net/browse/KIWI-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ