### PR TITLE
[KIWI-2873] - F2F | Fix F2F FE dev pipeline

### DIFF
--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -573,8 +573,14 @@ Resources:
       CodeUri: src/
       Environment:
         Variables:
-          DEV_IPV_F2F_STUB_URL: !Sub
+          DEV_IPV_F2F_STUB_URL: !If
+          - CreateDevResources
+          - !Sub
               - "https://${AWS::StackName}-${IPVSTUBURL}"
+              - IPVSTUBURL:
+                  !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
+          - !Sub
+              - "https://${IPVSTUBURL}"
               - IPVSTUBURL:
                   !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
           DEV_CRI_F2F_API_URL: !Sub


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Set IPV stub name correctly for build env for IPVStubRedirectFunction

### Why did it change

Inconsistent behaviour was being observed in the front end browser tests - dev was failing whilst build was passing. The tests were erroneously written against a journey that never completed and had been passing by chance rather than design. Build should also be failing which will be rectified by setting the redirect function IPV stub name correctly. The frontend browser tests will then be updated accordingly.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2873](https://govukverify.atlassian.net/browse/KIWI-2873)



[KIWI-2873]: https://govukverify.atlassian.net/browse/KIWI-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ