### PR TITLE
KIWI-2897 updating dynatrace layer version

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -353,7 +353,7 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Layers:
-      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_329_73_20260123-140641_with_collector_nodejs_arm:1
     Timeout: 30 # seconds
     Tracing: Active
     MemorySize: 1024


### PR DESCRIPTION
### What changed

Dynatrace layer update from `1.313.2` to `1.329`

### Why did it change

Dynatrace Lambda layer, at least version 1.325 is incompatible with the latest Lambda node 22 runtime being rolled out automically by AWS.
The risk is that lambda could be automatically updated at any time as per https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html#runtime-management-two-phase in this case the lambda would fail to start and you would see errors with the function execution timing out


- [KIWI-2897](https://govukverify.atlassian.net/browse/KIWI-2897)


[KIWI-2897]: https://govukverify.atlassian.net/browse/KIWI-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ