### PR TITLE
IPVStubRedirectFunction API URL corrected for build env

### DIFF
--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -583,8 +583,14 @@ Resources:
               - "https://${IPVSTUBURL}"
               - IPVSTUBURL:
                   !FindInMap [ Configuration, !Ref Environment, IPVSTUBURL ]
-          DEV_CRI_F2F_API_URL: !Sub
+          DEV_CRI_F2F_API_URL: !If
+          - CreateDevResources
+          - !Sub
               - "https://api-${BackendStack}.${DNSSUFFIX}"
+              - DNSSUFFIX:
+                  !FindInMap [ Configuration, !Ref Environment, DNSSUFFIX ]
+          - !Sub
+              - "https://api.${DNSSUFFIX}"
               - DNSSUFFIX:
                   !FindInMap [ Configuration, !Ref Environment, DNSSUFFIX ]
       Role: !GetAtt IPVStubLambdaRole.Arn


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Updated API URL in the IPV core stub for the build env

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
The URL was incorrectly configured for the IPVStubRedirectFunction 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2873](https://govukverify.atlassian.net/browse/KIWI-2873)


[KIWI-2873]: https://govukverify.atlassian.net/browse/KIWI-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ